### PR TITLE
Fix timezone change, notification, schedule, and config state bugs

### DIFF
--- a/src/app/core/services/notification.service.ts
+++ b/src/app/core/services/notification.service.ts
@@ -110,7 +110,7 @@ export class NotificationService {
           }
         }
         if (DefaultNotificationType === 'LOCAL') {
-          console.log('NOTIFICATIONS Scheduleing LOCAL notifications')
+          console.log('NOTIFICATIONS Scheduling LOCAL notifications')
           ;(<any>cordova).plugins.notification.local.on('click', notification =>
             this.evalTaskTiming(notification.data)
           )
@@ -126,7 +126,7 @@ export class NotificationService {
           )
         }
         if (DefaultNotificationType === 'FCM') {
-          console.log('NOTIFICATIONS Scheduleing FCM notifications')
+          console.log('NOTIFICATIONS Scheduling FCM notifications')
           console.log(fcmNotifications)
           for (let i = 0; i < fcmNotifications.length; i++) {
             FCMPlugin.upstream(
@@ -140,6 +140,7 @@ export class NotificationService {
             )
           }
         }
+        this.storage.set(StorageKeys.LAST_NOTIFICATION_UPDATE, Date.now())
       })
   }
 

--- a/src/app/pages/auth/containers/enrolment-page.component.html
+++ b/src/app/pages/auth/containers/enrolment-page.component.html
@@ -157,6 +157,7 @@
         <div
           padding
           class="bottom"
+          *ngIf="!authSuccess"
         >
           <button
             ion-button
@@ -201,6 +202,7 @@
       <div
         padding
         class="bottom"
+        *ngIf="!authSuccess"
       >
         <button
           ion-button

--- a/src/app/pages/auth/containers/enrolment-page.component.ts
+++ b/src/app/pages/auth/containers/enrolment-page.component.ts
@@ -236,8 +236,7 @@ export class EnrolmentPageComponent {
   }
 
   doAfterAuthentication() {
-    this.configService.fetchConfigState(true)
-    this.next()
+    this.configService.fetchConfigState(true).then(() => this.next())
   }
 
   displayErrorMessage(error) {

--- a/src/app/pages/auth/containers/enrolment-page.component.ts
+++ b/src/app/pages/auth/containers/enrolment-page.component.ts
@@ -62,6 +62,7 @@ export class EnrolmentPageComponent {
     ]),
     tokenName: new FormControl('', [Validators.required])
   })
+  authSuccess = false
 
   get tokenName() {
     return this.metaQRForm.get('tokenName')
@@ -209,6 +210,7 @@ export class EnrolmentPageComponent {
   }
 
   retrieveSubjectInformation() {
+    this.authSuccess = true
     this.authService.getSubjectInformation().then(res => {
       const subjectInformation: any = res
       const participantId = subjectInformation.externalId

--- a/src/app/pages/home/components/task-info/task-info.component.ts
+++ b/src/app/pages/home/components/task-info/task-info.component.ts
@@ -230,7 +230,6 @@ export class TaskInfoComponent implements OnChanges {
     const date = new Date()
     date.setTime(this.task['timestamp'])
     const hour = date.getHours()
-    // let hour12 = hour > 12 ? hour-12 : hour
     const formatedHour = this.formatSingleDigits(hour)
     return formatedHour
   }

--- a/src/app/pages/home/components/ticker-bar/ticker-bar.component.html
+++ b/src/app/pages/home/components/ticker-bar/ticker-bar.component.html
@@ -1,8 +1,4 @@
-<!-- Generated template for the TickerBar component -->
-<div
-  id="ticker-bar-container"
-  (click)="openReport()"
->
+<div id="ticker-bar-container">
   <div
     *ngFor="let item of tickerItems"
     class="ticker-item"

--- a/src/app/pages/home/containers/home-page.component.html
+++ b/src/app/pages/home/containers/home-page.component.html
@@ -117,7 +117,7 @@
     class="size-static footer"
   >
     <div
-      *ngIf="taskIsNow"
+      *ngIf="taskIsNow && !hasClickedStartButton"
       padding
     >
       <button

--- a/src/app/pages/home/containers/home-page.component.ts
+++ b/src/app/pages/home/containers/home-page.component.ts
@@ -66,7 +66,11 @@ export class HomePageComponent {
     public storage: StorageService,
     private platform: Platform,
     private kafka: KafkaService
-  ) {}
+  ) {
+    this.platform.resume.subscribe(e => {
+      this.kafka.sendAllAnswersInCache()
+    })
+  }
 
   ionViewWillEnter() {
     this.getElementsAttributes()
@@ -83,10 +87,6 @@ export class HomePageComponent {
     setInterval(() => {
       this.checkForNextTask()
     }, 1000)
-
-    this.platform.resume.subscribe(e => {
-      this.kafka.sendAllAnswersInCache()
-    })
 
     this.tasksService.sendNonReportedTaskCompletion()
   }

--- a/src/app/pages/settings/containers/settings-page.component.ts
+++ b/src/app/pages/settings/containers/settings-page.component.ts
@@ -250,11 +250,7 @@ export class SettingsPageComponent {
     this.showLoading = true
     this.configService.fetchConfigState(true).then(() => {
       this.loadSettings()
-      this.notificationService
-        .setNextXNotifications(DefaultNumberOfNotificationsToSchedule)
-        .then(() => {
-          this.showLoading = false
-        })
+      this.showLoading = false
     })
   }
 }


### PR DESCRIPTION
- Fetch config to reschedule tasks and notifications in splash page on timezone change (Solves #161)
- Fix promise callbacks in splash page
- Move setting of notification last update in storage to notifications service (because this hasn't been getting updated constantly)
- Remove redundant code in settings page

Depends on #172 