### PR TITLE
Add platform check when calling cordova Firebase plugins functions

### DIFF
--- a/src/app/core/services/config/remote-config.service.ts
+++ b/src/app/core/services/config/remote-config.service.ts
@@ -59,6 +59,15 @@ export interface RemoteConfig {
   getOrDefault(key: ConfigKeys, defaultValue: any): Promise<any>
 }
 
+class EmptyRemoteConfig implements RemoteConfig {
+  get(key: ConfigKeys): Promise<any> {
+    return Promise.resolve()
+  }
+  getOrDefault(key: ConfigKeys, defaultValue: any): Promise<string> {
+    return Promise.resolve(defaultValue)
+  }
+}
+
 class FirebaseRemoteConfig implements RemoteConfig {
   constructor(private logger: LogService) {}
 
@@ -96,9 +105,7 @@ export class FirebaseRemoteConfigService extends RemoteConfigService {
     private platform: Platform
   ) {
     super(storage)
-    this.configSubject = new BehaviorSubject(
-      new FirebaseRemoteConfig(this.logger)
-    )
+    this.configSubject = new BehaviorSubject(new EmptyRemoteConfig())
   }
 
   forceFetch(): Promise<RemoteConfig> {

--- a/src/app/core/services/notifications/fcm-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.ts
@@ -79,6 +79,7 @@ export class FcmNotificationService extends NotificationService {
   }
 
   private sendNotification(notification): Promise<void> {
+    if (!this.platform.is('cordova')) return Promise.resolve()
     FirebasePlugin.upstream(
       notification,
       succ => this.logger.log(succ),

--- a/src/app/core/services/usage/firebase-analytics.service.ts
+++ b/src/app/core/services/usage/firebase-analytics.service.ts
@@ -1,22 +1,21 @@
-import { Device } from '@ionic-native/device/ngx'
 import { Firebase } from '@ionic-native/firebase/ngx'
 import { Injectable } from '@angular/core'
-import { User } from '../../../shared/models/user'
 import { LogService } from '../misc/log.service'
+import { Platform } from 'ionic-angular'
+import { User } from '../../../shared/models/user'
 
 @Injectable()
 export class FirebaseAnalyticsService {
   constructor(
     private firebase: Firebase,
-    private device: Device,
-    private logger: LogService,
+    private platform: Platform,
+    private logger: LogService
   ) {}
 
   logEvent(event: string, params): Promise<any> {
     this.logger.log('Firebase Event', event)
-    if (!this.device.platform) {
+    if (!this.platform.is('cordova'))
       return Promise.resolve('Could not load firebase')
-    }
     return this.firebase
       .logEvent(event.toLowerCase(), params)
       .then((res: any) => {

--- a/src/app/pages/questions/services/audio-record.service.ts
+++ b/src/app/pages/questions/services/audio-record.service.ts
@@ -1,8 +1,8 @@
 import { DefaultAudioRecordOptions } from '../../../../assets/data/defaultConfig'
-import { Device } from '@ionic-native/device/ngx'
 import { File } from '@ionic-native/file/ngx'
 import { Injectable } from '@angular/core'
 import { LogService } from '../../../core/services/misc/log.service'
+import { Platform } from 'ionic-angular'
 
 declare var Media: any // stops errors w/ cordova-plugin-media-with-compression types
 
@@ -14,7 +14,7 @@ export class AudioRecordService {
 
   constructor(
     private file: File,
-    private device: Device,
+    private platform: Platform,
     private logger: LogService
   ) {}
 
@@ -38,13 +38,13 @@ export class AudioRecordService {
   }
 
   getFilePath() {
-    return this.device.platform == 'Android'
+    return this.platform.is('android')
       ? this.getDir() + this.fileName
       : this.fileName
   }
 
   getDir() {
-    return this.device.platform == 'Android'
+    return this.platform.is('android')
       ? this.file.dataDirectory
       : this.file.tempDirectory
   }

--- a/src/app/pages/splash/containers/splash-page.component.ts
+++ b/src/app/pages/splash/containers/splash-page.component.ts
@@ -2,7 +2,6 @@ import { NavController, NavParams } from 'ionic-angular'
 
 import { AlertService } from '../../../core/services/misc/alert.service'
 import { Component } from '@angular/core'
-import { Device } from '@ionic-native/device/ngx'
 import { EnrolmentPageComponent } from '../../auth/containers/enrolment-page.component'
 import { HomePageComponent } from '../../home/containers/home-page.component'
 import { LocKeys } from '../../../shared/enums/localisations'
@@ -22,7 +21,6 @@ export class SplashPageComponent {
     private splash: SplashService,
     private alertService: AlertService,
     private localization: LocalizationService,
-    private device: Device,
     private usage: UsageService
   ) {
     this.splash
@@ -39,10 +37,7 @@ export class SplashPageComponent {
         this.status = 'Sending missed questionnaire logs..'
         return this.splash.sendMissedQuestionnaireLogs()
       })
-      .catch(e => {
-        console.log('[SPLASH] Notifications error.')
-        if (this.device.platform) return this.showFetchConfigFail(e)
-      })
+      .catch(e => console.log('[SPLASH] Notifications error.'))
       .then(() => this.navCtrl.setRoot(HomePageComponent))
   }
 

--- a/src/app/shared/utilities/android-permission.ts
+++ b/src/app/shared/utilities/android-permission.ts
@@ -1,8 +1,8 @@
 import 'rxjs/add/operator/map'
 
 import { AndroidPermissions } from '@ionic-native/android-permissions/ngx'
-import { Device } from '@ionic-native/device/ngx'
 import { Injectable } from '@angular/core'
+import { Platform } from 'ionic-angular'
 
 @Injectable()
 export class AndroidPermissionUtility {
@@ -20,7 +20,7 @@ export class AndroidPermissionUtility {
   ]
 
   constructor(
-    private device: Device,
+    private platform: Platform,
     private androidPermissions: AndroidPermissions
   ) {}
 
@@ -31,7 +31,8 @@ export class AndroidPermissionUtility {
     if (this.isAndroid())
       this.androidPermissions
         .requestPermissions(this.androidPermissionList)
-        .then(success => {
+        .then(
+          success => {
             console.log(success)
             this.checkPermissions()
           },
@@ -101,12 +102,12 @@ export class AndroidPermissionUtility {
   checkPermission(permission): Promise<any> {
     return new Promise((resolve, reject) => {
       if (!this.isAndroid()) resolve(true)
-      this.androidPermissions.checkPermission(permission)
-        .then(success => {
+      this.androidPermissions.checkPermission(permission).then(
+        success => {
           if (success.hasPermission === true) {
             resolve(true)
           } else {
-            reject(new Error("No permission " + permission + " was given"))
+            reject(new Error('No permission ' + permission + ' was given'))
           }
         },
         error => {
@@ -127,11 +128,13 @@ export class AndroidPermissionUtility {
   }
 
   getWriteExternalStorage_permission() {
-    return this.fetchPermission(this.androidPermissions.PERMISSION.WRITE_EXTERNAL_STORAGE)
+    return this.fetchPermission(
+      this.androidPermissions.PERMISSION.WRITE_EXTERNAL_STORAGE
+    )
   }
 
   isAndroid() {
-    return this.device.platform == 'Android'
+    return this.platform.is('android')
   }
 
   // TODO: Add required permissions as above


### PR DESCRIPTION
- Handles cordova errors (`cordova_not_available`) when running `ionic serve` by adding a platform check if the device is running cordova before calling cordova Firebase plugin functions 
- Also switch to `ionic-platform` from `cordova-plugin-device` (in services using it) for checking platform for uniformity