### PR TITLE
perf: ensure that specifications are fetched once

### DIFF
--- a/src/app/core/services/kafka/schema.service.ts
+++ b/src/app/core/services/kafka/schema.service.ts
@@ -134,9 +134,7 @@ export class SchemaService {
       })
   }
 
-  getKafkaTopic(name, avsc): Promise<string> {
-    const type = name.toLowerCase()
-    const defaultTopic = `${avsc}_${name}`
+  getRadarSpecifications(): Promise<any[] | null> {
     return this.remoteConfig
       .read()
       .then(config =>
@@ -146,13 +144,21 @@ export class SchemaService {
         )
       )
       .then(url => this.http.get(url).toPromise())
-      .then(res => {
-        const schemaSpecs = YAML.parse(atob(res['content'])).data
-        const topic = schemaSpecs.find(t => t.type.toLowerCase() == type).topic
-        if (topic) return topic
-        else throw new Error('Failed to get Kafka topic')
+      .then(res => YAML.parse(atob(res['content'])).data)
+      .catch(e => {
+        this.logger.error("Failed to get valid RADAR Schema specifications", e)
+        return null
       })
-      .catch(e => defaultTopic)
+  }
+
+  getKafkaTopic(specifications: any[] | null, name, avsc): string {
+    const type = name.toLowerCase()
+    const defaultTopic = `${avsc}_${name}`
+    if (specifications) {
+      const spec = specifications.find(t => t.type.toLowerCase() == type)
+      return spec && spec.topic ? spec.topic : defaultTopic;
+    }
+    return defaultTopic
   }
 
   getLatestKafkaSchemaVersion(


### PR DESCRIPTION
Specifications are still fetched each time the Kafka sending is invoked. Note that on a missing or bad specification, the uploader still tries to upload to the default topic.