### PR TITLE
Fix kafka service: remove dependency on library

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
         "ionic-angular": "^3.9.8",
         "ionic-mocks": "^1.3.0",
         "ionicons": "^4.6.3",
-        "kafka-rest": "^0.0.5",
         "moment": "^2.22.2",
         "ng2-fittext": "^1.2.6",
         "ngx-moment": "^3.3.0",

--- a/src/app/core/services/kafka/kafka.service.spec.ts
+++ b/src/app/core/services/kafka/kafka.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClient, HttpHandler } from '@angular/common/http'
 import { TestBed } from '@angular/core/testing'
 
 import {
@@ -10,9 +11,9 @@ import {
 import { LogService } from '../misc/log.service'
 import { StorageService } from '../storage/storage.service'
 import { TokenService } from '../token/token.service'
+import { AnalyticsService } from '../usage/analytics.service'
 import { KafkaService } from './kafka.service'
 import { SchemaService } from './schema.service'
-import { AnalyticsService } from '../usage/analytics.service';
 
 describe('KafkaService', () => {
   let service
@@ -21,6 +22,8 @@ describe('KafkaService', () => {
     TestBed.configureTestingModule({
       providers: [
         KafkaService,
+        HttpClient,
+        HttpHandler,
         { provide: StorageService, useClass: StorageServiceMock },
         { provide: LogService, useClass: LogServiceMock },
         { provide: TokenService, useClass: TokenServiceMock },

--- a/src/app/core/services/kafka/kafka.service.ts
+++ b/src/app/core/services/kafka/kafka.service.ts
@@ -1,7 +1,11 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http'
 import { Injectable } from '@angular/core'
-import * as KafkaRest from 'kafka-rest'
 
-import { DefaultKafkaURI } from '../../../../assets/data/defaultConfig'
+import {
+  DefaultClientAcceptType,
+  DefaultKafkaRequestContentType,
+  DefaultKafkaURI
+} from '../../../../assets/data/defaultConfig'
 import { DataEventType } from '../../../shared/enums/events'
 import { StorageKeys } from '../../../shared/enums/storage'
 import { CacheValue } from '../../../shared/models/cache'
@@ -14,6 +18,8 @@ import { SchemaService } from './schema.service'
 
 @Injectable()
 export class KafkaService {
+  URI_topics: string = '/topics/'
+
   private readonly KAFKA_STORE = {
     LAST_UPLOAD_DATE: StorageKeys.LAST_UPLOAD_DATE,
     CACHE_ANSWERS: StorageKeys.CACHE_ANSWERS
@@ -27,7 +33,8 @@ export class KafkaService {
     private token: TokenService,
     private schema: SchemaService,
     private analytics: AnalyticsService,
-    private logger: LogService
+    private logger: LogService,
+    private http: HttpClient
   ) {
     this.updateURI()
   }
@@ -75,10 +82,10 @@ export class KafkaService {
     this.setCacheSending(true)
     return Promise.all([
       this.getCache(),
-      this.getKafkaInstance(),
+      this.getKafkaHeaders(),
       this.schema.getRadarSpecifications()
     ])
-      .then(([cache, kafka, specifications]) => {
+      .then(([cache, headers, specifications]) => {
         const sendPromises = Object.entries(cache)
           .filter(([k]) => k)
           .map(([k, v]: any) => {
@@ -87,7 +94,7 @@ export class KafkaService {
               v.name,
               v.avsc
             )
-            return this.sendToKafka(topic, k, v, kafka).catch(e =>
+            return this.sendToKafka(topic, k, v, headers).catch(e =>
               this.logger.error('Failed to send data from cache to kafka', e)
             )
           })
@@ -99,22 +106,21 @@ export class KafkaService {
         )
         return keys
       })
-
       .catch(e => {
         this.setCacheSending(false)
         return [this.logger.error('Failed to send all data from cache', e)]
       })
   }
 
-  sendToKafka(topic: string, k: number, v: CacheValue, kafka): Promise<any> {
+  sendToKafka(topic: string, k: number, v: CacheValue, headers): Promise<any> {
     return this.schema
-      .convertToAvro(v.kafkaObject, topic, this.BASE_URI)
+      .getKafkaPayload(v.kafkaObject, topic, this.BASE_URI)
       .then(data =>
-        kafka
-          .topic(topic)
-          .produce(data.schemaId, data.schemaInfo, data.payload, e =>
-            e ? Promise.reject() : Promise.resolve()
-          )
+        this.http
+          .post(this.KAFKA_CLIENT_URL + this.URI_topics + topic, data, {
+            headers: headers
+          })
+          .toPromise()
       )
       .then(() => this.sendDataEvent(DataEventType.SEND_SUCCESS, v))
       .then(() => k)
@@ -144,15 +150,17 @@ export class KafkaService {
     })
   }
 
-  getKafkaInstance() {
+  getKafkaHeaders() {
     return Promise.all([this.updateURI(), this.token.refresh()])
       .then(() => this.token.getTokens())
-      .then(tokens => {
-        const headers = { Authorization: 'Bearer ' + tokens.access_token }
-        return new KafkaRest({ url: this.KAFKA_CLIENT_URL, headers: headers })
-      })
+      .then(tokens =>
+        new HttpHeaders()
+          .set('Authorization', 'Bearer ' + tokens.access_token)
+          .set('Content-Type', DefaultKafkaRequestContentType)
+          .set('Accept', DefaultClientAcceptType)
+      )
       .catch(e => {
-        throw this.logger.error('Could not initiate kafka connection', e)
+        throw this.logger.error('Could not create kafka headers', e)
       })
   }
 

--- a/src/app/core/services/kafka/schema.service.ts
+++ b/src/app/core/services/kafka/schema.service.ts
@@ -95,7 +95,8 @@ export class SchemaService {
       case SchemaType.APP_EVENT:
         const Event: EventValueExport = {
           time: getSeconds({ milliseconds: this.getUniqueTimeNow() }),
-          eventType: payload.eventType
+          eventType: payload.eventType,
+          questionnaireName: payload.questionnaireName
         }
         return Event
     }
@@ -122,8 +123,8 @@ export class SchemaService {
           value: this.convertToAvro(value, kafkaObject.value)
         }
         return {
-          key_schema: keySchemaMetadata.schema,
-          value_schema: valueSchemaMetadata.schema,
+          key_schema_id: keySchemaMetadata.id,
+          value_schema_id: valueSchemaMetadata.id,
           records: [payload]
         }
       })

--- a/src/app/shared/models/event.ts
+++ b/src/app/shared/models/event.ts
@@ -1,4 +1,5 @@
 export interface EventValueExport {
   time: number
   eventType: string
+  questionnaireName: string
 }

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -192,6 +192,10 @@ export const DefaultTimeInterval = { unit: 'day', amount: 1 }
 // KAFKA
 
 export const DefaultKafkaURI = '/kafka'
+export const DefaultKafkaRequestContentType =
+  'application/vnd.kafka.avro.v1+json'
+export const DefaultClientAcceptType =
+  'application/vnd.kafka.v1json, application/vnd.kafka+json; q=0.9, application/json; q=0.8'
 
 export const DefaultNumberOfCompletionLogsToSend = 10
 

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -193,9 +193,9 @@ export const DefaultTimeInterval = { unit: 'day', amount: 1 }
 
 export const DefaultKafkaURI = '/kafka'
 export const DefaultKafkaRequestContentType =
-  'application/vnd.kafka.avro.v1+json'
+  'application/vnd.kafka.avro.v2+json'
 export const DefaultClientAcceptType =
-  'application/vnd.kafka.v1json, application/vnd.kafka+json; q=0.9, application/json; q=0.8'
+  'application/vnd.kafka.v2+json, application/vnd.kafka+json; q=0.9, application/json; q=0.8'
 
 export const DefaultNumberOfCompletionLogsToSend = 10
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,11 +1545,6 @@ async@^2.1.2, async@^2.5.0, async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
-async@~0.9.0:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
-  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -6692,13 +6687,6 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
-
-kafka-rest@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/kafka-rest/-/kafka-rest-0.0.5.tgz#7b8ff99bd259e6b4b14c266884424d81a6ffdd9f"
-  integrity sha1-e4/5m9JZ5rSxTCZohEJNgab/3Z8=
-  dependencies:
-    async "~0.9.0"
 
 karma-browserify@^6.1.0:
   version "6.1.0"


### PR DESCRIPTION
- Fixes/refactors kafka service to directly use HTTP requests to send data to kafka instead of relying on the `kafka-rest` library