### PR TITLE
Translations added: Hebrew & Polish + small changes

### DIFF
--- a/src/assets/data/localisations.ts
+++ b/src/assets/data/localisations.ts
@@ -6,7 +6,9 @@ export const Localisations = {
     en: '',
     es: '',
     it: '',
-    nl: ''
+    nl: '',
+    pl: '',
+    hb: ''
   },
   ENROL_WELCOME_1: {
     da: 'Velkommen',
@@ -14,7 +16,9 @@ export const Localisations = {
     en: 'Welcome',
     es: 'Bienvenido',
     it: 'Benvenuto',
-    nl: 'Welkom'
+    nl: 'Welkom',
+    pl: 'Witamy',
+    hb: ''
   },
   ENROL_WELCOME_2: {
     da: 'til RADAR-Base',
@@ -22,7 +26,9 @@ export const Localisations = {
     en: 'to RADAR-Base',
     es: 'a RADAR-Base',
     it: 'in RADAR-Base',
-    nl: 'bij RADAR-Base'
+    nl: 'bij RADAR-Base',
+    pl: 'w RADAR-CNS',
+    hb: ''
   },
   ENROL_WELCOME_DESC: {
     da:
@@ -36,7 +42,11 @@ export const Localisations = {
     it:
       'Grazie per aver preso parte al nostro studio. Iniziamo il processo di arruolamento.',
     nl:
-      'Bedankt voor uw deelname aan dit onderzoek. Laten we starten met het registratie-proces.'
+      'Bedankt voor uw deelname aan dit onderzoek. Laten we starten met het registratie-proces.',
+    pl: 
+      'Dziękujemy za wzięcie udziału w badaniu. Przejdź przez proces rejestracji, byś mógł zacząć korzystać z aplikacji',
+    hb: 
+      ''  
   },
   ENROL_REGISTRATION: {
     da: 'Registrering',
@@ -44,7 +54,9 @@ export const Localisations = {
     en: 'Registration',
     es: 'Registro',
     it: 'Registrazione',
-    nl: 'Registratie'
+    nl: 'Registratie',
+    pl: 'Rejestracja',
+    hb: ''
   },
   ENROL_REGISTRATION_DESC: {
     da:
@@ -58,21 +70,29 @@ export const Localisations = {
     it:
       'Prima di poter usare questa app, devi registrarti. Puoi scansionare il codice QR o inserire il token.',
     nl:
-      'Voordat u de app kunt gebruiken, moeten we de app eerst registreren. U kunt de QR code scannen of het token invoeren.'
+      'Voordat u de app kunt gebruiken, moeten we de app eerst registreren. U kunt de QR code scannen of het token invoeren.',
+    pl: 
+      'Zanim będziesz mógł korzystać z aplikacji, musisz się zarejestrować. Możesz zeskanować kod QR lub wpisać Token',
+    hb: 
+      ''  
   },
   ENROL_REGISTRATION_SCAN_DESC: {
     da:
-      'Klik på "Scan" knappen og hold kameraet over QR-koden som du får udleveret af forskeren. Du kan se et eksempel på en QR-kode herunder.',
+      "Klik på 'Scan' knappen og hold kameraet over QR-koden som du får udleveret af forskeren. Du kan se et eksempel på en QR-kode herunder.",
     de:
-      'Klicken Sie auf die Schaltfläche "Scannen" und richten Sie die Kamera auf den von Ihrem Forscher angegebenen QR-Code. Ein Beispiel für einen QR-Code finden Sie unten.',
+      "Klicken Sie auf die Schaltfläche 'Scannen' und richten Sie die Kamera auf den von Ihrem Forscher angegebenen QR-Code. Ein Beispiel für einen QR-Code finden Sie unten.",
     en:
-      'Click the "Scan" button and point the camera onto the QR code, given by your researcher. An example QR code is below.',
+      "Click the 'Scan' button and point the camera onto the QR code, given by your researcher. An example QR code is below.",
     es:
-      'Presione el botón "Escanear" e ingrese el código QR que le dio el personal del estudio. A continuación puede ver un ejemplo de código QR',
+      "Presione el botón 'Escanear' e ingrese el código QR que le dio el personal del estudio. A continuación puede ver un ejemplo de código QR",
     it:
-      'Premi il pulsante "Scan" e inquadra il codice QR che hai ricevuto dal personale dello studio. Qui sotto puoi vedere un QR di esempio.',
+      "Premi il pulsante 'Scan' e inquadra il codice QR che hai ricevuto dal personale dello studio. Qui sotto puoi vedere un QR di esempio.",
     nl:
-      'Klik op de "Scan" knop en richt de camera op de QR code die u heeft ontvangen van de onderzoeker. Hieronder staat een voorbeeld van een QR code afgebeeld.'
+      "Klik op de 'Scan' knop en richt de camera op de QR code die u heeft ontvangen van de onderzoeker. Hieronder staat een voorbeeld van een QR code afgebeeld.",
+    pl: 
+      "Kliknij przycisk Skanuj i skieruj aparat telefonu na kod QR, który otrzymałeś od badacza. Przykładowy kod QR znajduje się poniżej.",
+    hb: 
+      ""  
   },
   ENROL_REGISTRATION_TOKEN_DESC: {
     da:
@@ -86,7 +106,11 @@ export const Localisations = {
     it:
       'Inserisci il token. Questo dovrebbe essere disponibile sotto il codice QR sul portale di gestione. Se non è presente, scansiona il codice QR.',
     nl:
-      'Voer het token in. Dit moet beschikbaar zijn onder de QR-code op Management Portal. Indien niet aanwezig, scan de QR-code.'
+      'Voer het token in. Dit moet beschikbaar zijn onder de QR-code op Management Portal. Indien niet aanwezig, scan de QR-code.',
+    pl: 
+      'Wprowadź Token. Powinien być widoczny poniżej kodu QR w Mahagement Portal. Jeśli go tam nie znajdziesz, zeskanuj kod QR.',
+    hb: 
+      ''  
   },
   ENROL_PREFERENCES: {
     da: 'Præferencer',
@@ -94,7 +118,9 @@ export const Localisations = {
     en: 'Preferences',
     es: 'Preferencias',
     it: 'Preferenze',
-    nl: 'Voorkeurs instellingen'
+    nl: 'Voorkeurs instellingen',
+    pl: 'Preferencje',
+    hb: ''
   },
   ENROL_PREFERENCES_DESC: {
     da:
@@ -108,7 +134,11 @@ export const Localisations = {
     it:
       'Ti invieremo ogni settimana un riepilogo dei dati raccolti. Sentiti libero di selezionare solo gli argomenti di cui vuoi ricevere le informazioni.',
     nl:
-      'We zullen u wekelijks samenvattingen sturen over uw verzamelde gegevens. U kunt zelf de onderwerpen selecteren waarover uw informatie wilt ontvangen.'
+      'We zullen u wekelijks samenvattingen sturen over uw verzamelde gegevens. U kunt zelf de onderwerpen selecteren waarover uw informatie wilt ontvangen.',
+    pl: 
+      'Co tydzień wyślemy Ci podsumowanie zebranych przez nas danych. Wybierz wszystkie tematy, na temat których chciałbyś uzyskiwać informacje.',
+    hb: 
+      ''  
   },
   ENROL_REGISTRATION_COMPLETE: {
     da: 'Registrering Afsluttet',
@@ -116,15 +146,19 @@ export const Localisations = {
     en: 'Registration Complete',
     es: 'Registro Completo',
     it: 'Registrazione Completa',
-    nl: 'Registratie Compleet'
+    nl: 'Registratie Compleet',
+    pl: '',
+    hb: ''
   },
   ENROL_REGISTRATION_COMPLETE_DESC: {
-    da: `Du er nu med tilmelding til undersøgelsen. Klik på 'Afslut' for at begynde at generere din spørgeskemaplan og dine meddelelser.`,
-    de: `Sie haben sich jetzt erfolgreich für die Studie angemeldet. Klicken Sie auf "Fertig", um den Zeitplan und die Benachrichtigungen für Ihren Fragebogen zu erstellen.`,
-    en: `You have now successfully enrolled in the study. Click 'Finish' to start generating your questionnaire schedule and notifications.`,
-    es: `Ahora se ha inscrito con éxito en el estudio. Haga clic en 'Finalizar' para comenzar a generar su calendario de cuestionarios y notificaciones.`,
-    it: `Ora ti sei iscritto con successo allo studio. Fai clic su "Fine" per iniziare a generare la pianificazione del questionario e le notifiche.`,
-    nl: `U bent nu succesvol ingeschreven voor het onderzoek. Klik op 'Voltooid' om uw vragenlijstschema en meldingen te genereren.`
+    da: "Du er nu med tilmelding til undersøgelsen. Klik på 'Afslut' for at begynde at generere din spørgeskemaplan og dine meddelelser.",
+    de: "Sie haben sich jetzt erfolgreich für die Studie angemeldet. Klicken Sie auf 'Fertig', um den Zeitplan und die Benachrichtigungen für Ihren Fragebogen zu erstellen.",
+    en: "You have now successfully enrolled in the study. Click 'Finish' to start generating your questionnaire schedule and notifications.",
+    es: "Ahora se ha inscrito con éxito en el estudio. Haga clic en 'Finalizar' para comenzar a generar su calendario de cuestionarios y notificaciones.",
+    it: "Ora ti sei iscritto con successo allo studio. Fai clic su 'Fine' per iniziare a generare la pianificazione del questionario e le notifiche.",
+    nl: "U bent nu succesvol ingeschreven voor het onderzoek. Klik op 'Voltooid' om uw vragenlijstschema en meldingen te genereren.",
+    pl: '',
+    hb: ''
   },
   FINISH_THANKS: {
     da: 'Tak fordi du udfyldte spørgeskemaet.',
@@ -132,7 +166,9 @@ export const Localisations = {
     en: 'Thank you for completing the questionnaire.',
     es: 'Gracias por completar el cuestionario.',
     it: 'Grazie per aver completato il questionario.',
-    nl: 'Bedankt voor het invullen van de vragenlijst.'
+    nl: 'Bedankt voor het invullen van de vragenlijst.',
+    pl: 'Dziękujemy za wypełnienie ankiety.',
+    hb: ''
   },
   FINISH_NEXT_TASK_REMINDER: {
     da: 'Husk, du har stadig udestående opgaver!',
@@ -140,7 +176,9 @@ export const Localisations = {
     en: 'Remember, you still have tasks outstanding!',
     es: 'Recuerde, todavía tiene tareas pendientes!',
     it: 'Ricorda, hai ancora delle attività in sospeso!',
-    nl: 'Denk eraan, je hebt nog steeds taken openstaan!'
+    nl: 'Denk eraan, je hebt nog steeds taken openstaan!',
+    pl: 'Pamiętaj, że zostały Ci jeszcze zadania do dokończenia!',
+    hb: ''
   },
   FINISH_COMPLETED_IN_CLINIC: {
     da: 'Afsluttet i klinik?',
@@ -148,7 +186,9 @@ export const Localisations = {
     en: 'Completed in clinic?',
     es: 'Completado durante la visita clínica',
     it: 'Completato in clinica?',
-    nl: 'Voltooid in de kliniek?'
+    nl: 'Voltooid in de kliniek?',
+    pl: '',
+    hb: ''
   },
   CALENDAR_ESM_MISSED_TITLE: {
     da: 'Blokeret',
@@ -156,7 +196,9 @@ export const Localisations = {
     en: 'Blocked',
     es: 'Bloqueado',
     it: 'Bloccato',
-    nl: 'Geblokkeerd'
+    nl: 'Geblokkeerd',
+    pl: 'Zablokowane',
+    hb: ''
   },
   CALENDAR_ESM_MISSED_DESC: {
     da: 'Spørgsmålet kan ikke besvares længere.',
@@ -169,7 +211,11 @@ export const Localisations = {
     it:
       'Sfortunatamente, puoi rispondere a questo questionario solo al momento della notifica.',
     nl:
-      'Helaas kunt u deze vragenlijst alleen op het aangegeven tijdstip beantwoorden.'
+      'Helaas kunt u deze vragenlijst alleen op het aangegeven tijdstip beantwoorden.',
+    pl: 
+      'Niestety kwestionariusz można wypełniać tylko po otrzymaniu powiadomienia',
+    hb: 
+      ''  
   },
   CLINICAL_TASKS: {
     da: 'Kliniske vurderinger',
@@ -177,7 +223,9 @@ export const Localisations = {
     en: 'Clinical assessments',
     es: 'Evaluaciones clínicas',
     it: 'Valutazioni cliniche',
-    nl: 'Klinische beoordelingen'
+    nl: 'Klinische beoordelingen',
+    pl: 'Ocena kliniczna',
+    hb: ''
   },
   SETTINGS_SETTINGS: {
     da: 'Indstillinger',
@@ -185,7 +233,9 @@ export const Localisations = {
     en: 'Settings',
     es: 'Ajustes',
     it: 'Impostazioni',
-    nl: 'Instellingen'
+    nl: 'Instellingen',
+    pl: 'Ustawienia',
+    hb: ''
   },
   SETTINGS_PARTICIPANTID: {
     da: 'Bruger ID',
@@ -193,7 +243,9 @@ export const Localisations = {
     en: 'User ID',
     es: 'Código Usuario',
     it: 'ID utente',
-    nl: 'Gebruikers ID'
+    nl: 'Gebruikers ID',
+    pl: 'ID użytkownika',
+    hb: ''
   },
   SETTINGS_PROJECTNAME: {
     da: 'Projektnavn',
@@ -201,7 +253,9 @@ export const Localisations = {
     en: 'Project Name',
     es: 'Nombre del proyecto',
     it: 'Nome del progetto',
-    nl: 'Project naam'
+    nl: 'Project naam',
+    pl: 'Nazwa projektu',
+    hb: ''
   },
   SETTINGS_USER_INFO: {
     da: 'Bruger information',
@@ -209,7 +263,9 @@ export const Localisations = {
     en: 'User Info',
     es: 'Información para el usuario',
     it: 'Informazioni utente',
-    nl: 'Gebruikersinformatie'
+    nl: 'Gebruikersinformatie',
+    pl: 'Informacje o użytkowniku',
+    hb: ''
   },
   SETTINGS_ENROL_DATE: {
     da: 'Registreringsdata',
@@ -217,7 +273,9 @@ export const Localisations = {
     en: 'Enrolment Date',
     es: 'Fecha de registro',
     it: 'Data di arruolamento',
-    nl: 'Datum van inclusie'
+    nl: 'Datum van inclusie',
+    pl: 'Data rejestracji',
+    hb: ''
   },
   SETTINGS_LANGUAGE: {
     da: 'Sprog',
@@ -225,7 +283,9 @@ export const Localisations = {
     en: 'Language',
     es: 'Idioma',
     it: 'Lingua',
-    nl: 'Taal'
+    nl: 'Taal',
+    pl: 'Język',
+    hb: ''
   },
   SETTINGS_LANGUAGE_ALERT: {
     da: 'Vælg dit sprog',
@@ -233,7 +293,9 @@ export const Localisations = {
     en: 'Select your Language',
     es: 'Seleccione su idioma',
     it: 'Seleziona la lingua desiderata',
-    nl: 'Kies uw taal'
+    nl: 'Kies uw taal',
+    pl: 'Wybierz język',
+    hb: ''
   },
   SETTINGS_NOTIFICATIONS: {
     da: 'Notifikationer',
@@ -241,7 +303,9 @@ export const Localisations = {
     en: 'Notifications',
     es: 'Notificaciones',
     it: 'Notifiche',
-    nl: 'Notificaties'
+    nl: 'Notificaties',
+    pl: 'Powiadomienia',
+    hb: ''
   },
   SETTINGS_NOTIFICATIONS_SOUND: {
     da: 'Lyd',
@@ -249,7 +313,9 @@ export const Localisations = {
     en: 'Sound',
     es: 'Sonido',
     it: 'Suoneria',
-    nl: 'Geluid'
+    nl: 'Geluid',
+    pl: 'Dźwięk',
+    hb: ''
   },
   SETTINGS_NOTIFICATIONS_VIBRATION: {
     da: 'Vibration',
@@ -257,7 +323,9 @@ export const Localisations = {
     en: 'Vibration',
     es: 'Vibración',
     it: 'Vibrazione',
-    nl: 'Trillen'
+    nl: 'Trillen',
+    pl: 'Wibracje',
+    hb: ''
   },
   SETTINGS_NOTIFICATIONS_NIGHTMOD: {
     da: 'Nattilstand',
@@ -265,18 +333,27 @@ export const Localisations = {
     en: 'Night Mode',
     es: 'Modalidad nocturna',
     it: 'Modalità notte',
-    nl: 'Nachtmodus'
+    nl: 'Nachtmodus',
+    pl: 'Tryb nocny',
+    hb: ''
   },
   SETTINGS_NOTIFICATIONS_NIGHTMOD_DESC: {
-    da: 'Nattilstand stopper alle notifikationer imellem kl. 22:00 og 07:30.',
+    da: 
+      'Nattilstand stopper alle notifikationer imellem kl. 22:00 og 07:30.',
     de:
       'Der Nachtmodus stoppt alle Benachrichtigungen zwischen 22:00 und 07:30.',
-    en: 'Night Mode stops all notifications between 22:00 and 07:30.',
+    en: 
+      'Night Mode stops all notifications between 22:00 and 07:30.',
     es:
       'La modalidad nocturna detiene todas las notificaciones entre las  22 y las  7:30 horas',
     it:
       "La modalità notte bloccherà tutte le notifiche dell'app tra le 22:00 e le 7:30.",
-    nl: 'De nachtmodus blokkeert alle notificaties tussen 22:00u en 7:30u.'
+    nl: 
+      'De nachtmodus blokkeert alle notificaties tussen 22:00u en 7:30u.',
+    pl: 
+      'Tryb nocny blokuje wszystkie powiadomienia między 22:00 a 07:30.',
+    hb: 
+      ''
   },
   SETTINGS_REPORT: {
     da: 'Ugentlig rapport',
@@ -284,7 +361,9 @@ export const Localisations = {
     en: 'Weekly Reports',
     es: 'Informe semanal',
     it: 'Report settimanale',
-    nl: 'Wekelijkse rapporten'
+    nl: 'Wekelijkse rapporten',
+    pl: 'Raport tygodniowy',
+    hb: ''
   },
   SETTINGS_VERSION: {
     da: 'Version',
@@ -292,7 +371,9 @@ export const Localisations = {
     en: 'Version',
     es: 'Versión',
     it: 'Versione',
-    nl: 'Versie'
+    nl: 'Versie',
+    pl: 'Wersja',
+    hb: ''
   },
   SETTINGS_CONFIGURATION: {
     da: 'Konfiguration',
@@ -300,7 +381,9 @@ export const Localisations = {
     en: 'Configuration',
     es: 'Configuración',
     it: 'Configurazione',
-    nl: 'Configuratie'
+    nl: 'Configuratie',
+    pl: 'Konfiguracja',
+    hb: ''
   },
   SETTINGS_SCHEDULE: {
     da: 'Tidsplan',
@@ -308,7 +391,9 @@ export const Localisations = {
     en: 'Schedule',
     es: 'Programa',
     it: 'Programma',
-    nl: 'Schema'
+    nl: 'Schema',
+    pl: 'Plan',
+    hb: ''
   },
   SETTINGS_RESET_ALERT: {
     da: 'Nulstil App',
@@ -316,26 +401,37 @@ export const Localisations = {
     en: 'Reset App',
     es: 'Reiniciar, la aplicación',
     it: 'Reset app',
-    nl: 'Reset app'
+    nl: 'Reset app',
+    pl: 'Zresetuj aplikację',
+    hb: ''
   },
   SETTINGS_RESET_ALERT_DESC: {
     da: 'Du er ved at nulstille appen.',
     de: 'Sie sind dabei, die App zurückzusetzen.',
     en: 'You are about to reset the app.',
     es: 'Estás a punto de reiniciar la aplicación.',
-    it: `Stai per ripristinare l'app.`,
-    nl: 'U staat op het punt de app opnieuw in te stellen.'
+    it: "Stai per ripristinare l'app.",
+    nl: 'U staat op het punt de app opnieuw in te stellen.',
+    pl: '',
+    hb: ''
   },
   SETTINGS_RESET_ALERT_OPTION_DESC: {
-    da: `Scegli di ripristinare solo la configurazione e i dati dell'app oppure eseguire un ripristino completo e ripetere la registrazione.`,
+    da: 
+      'Vælg kun at nulstille appkonfiguration og data, eller udfør en fuldstændig nulstilling og tilmelding.',
     de:
       'Wählen Sie diese Option, um nur die App-Konfiguration und -Daten zurückzusetzen, oder führen Sie einen vollständigen Reset und eine erneute Registrierung durch.',
     en:
       'Choose to reset app configuration and data only or do a full reset and re-enrol.',
     es:
       'Elija restablecer la configuración de la aplicación y solo los datos o realice un reinicio completo y vuelva a inscribirse.',
-    it: `Scegli di ripristinare solo la configurazione e i dati dell'app oppure eseguire un ripristino completo e ripetere la registrazione.`,
-    nl: `Kies ervoor om de app-configuratie en -gegevens alleen opnieuw in te stellen of een volledige reset uit te voeren en opnieuw in te schrijven.`
+    it: 
+      "Scegli di ripristinare solo la configurazione e i dati dell'app oppure eseguire un ripristino completo e ripetere la registrazione.",
+    nl: 
+      "Kies ervoor om de app-configuratie en -gegevens alleen opnieuw in te stellen of een volledige reset uit te voeren en opnieuw in te schrijven.",
+    pl:
+      '',
+    hb: 
+      ''
   },
   SETTINGS_CACHE: {
     da: 'Cache',
@@ -343,7 +439,9 @@ export const Localisations = {
     en: 'Cache',
     es: 'Cache',
     it: 'Cache',
-    nl: 'Cache'
+    nl: 'Cache',
+    pl: 'Pamięć podręczna (cache)',
+    hb: ''
   },
   SETTINGS_CACHE_SIZE: {
     da: 'Størrelse',
@@ -351,7 +449,9 @@ export const Localisations = {
     en: 'Size',
     es: 'Tamaño',
     it: 'Dimensione',
-    nl: 'Grootte'
+    nl: 'Grootte',
+    pl: 'Rozmiar',
+    hb: ''
   },
   SETTINGS_LAST_UPLOAD_TO_SERVER: {
     da: 'Sidste upload til server',
@@ -359,7 +459,9 @@ export const Localisations = {
     en: 'Last Upload to Server',
     es: 'Última carga al servidor',
     it: 'Ultimo caricamento sul server',
-    nl: 'Laatste upload naar server'
+    nl: 'Laatste upload naar server',
+    pl: 'Ostatnie wysyłanie na serwer',
+    hb: ''
   },
   SETTINGS_DEBUGGING: {
     da: 'Debugging',
@@ -367,7 +469,9 @@ export const Localisations = {
     en: 'Debugging',
     es: 'Depuración',
     it: 'Debug',
-    nl: 'Debugging'
+    nl: 'Debugging',
+    pl: 'Debugowanie',
+    hb: ''
   },
   SETTINGS_GENERATE_NOTIFS: {
     da: 'Generer Testmeddelelse',
@@ -375,7 +479,9 @@ export const Localisations = {
     en: 'Generate Test Notifications',
     es: 'Generar Notificación de Prueba',
     it: 'Genera Notifica di Prova',
-    nl: 'Genereer Testmelding'
+    nl: 'Genereer Testmelding',
+    pl: '',
+    hb: ''
   },
   SETTINGS_LOG_NOTIFS: {
     da: 'Logmeddelelser',
@@ -383,7 +489,9 @@ export const Localisations = {
     en: 'Log Notifications',
     es: 'Notificaciones de Registro',
     it: 'Registra le Notifiche',
-    nl: 'Logmeldingen'
+    nl: 'Logmeldingen',
+    pl: '',
+    hb: ''
   },
   SETTINGS_SEND_CACHED_DATA: {
     da: 'Send Cachelagrede Data',
@@ -391,7 +499,9 @@ export const Localisations = {
     en: 'Send Cached Data',
     es: 'Enviar Datos en Caché',
     it: 'Invia Dati Memorizzati nella Cache',
-    nl: 'Gegevens in Cache Verzenden'
+    nl: 'Gegevens in Cache Verzenden',
+    pl: '',
+    hb: ''
   },
   LANGUAGE_ENGLISH: {
     da: 'Engelsk',
@@ -399,7 +509,9 @@ export const Localisations = {
     en: 'English',
     es: 'Inglés',
     it: 'Inglese',
-    nl: 'Engels'
+    nl: 'Engels',
+    pl: 'Angielski',
+    hb: ''
   },
   LANGUAGE_SPANISH: {
     da: 'Spansk',
@@ -407,7 +519,9 @@ export const Localisations = {
     en: 'Spanish',
     es: 'Español',
     it: 'Spagnolo',
-    nl: 'Spaans'
+    nl: 'Spaans',
+    pl: 'Hiszpański',
+    hb: ''
   },
   LANGUAGE_ITALIAN: {
     da: 'Italiensk',
@@ -415,7 +529,9 @@ export const Localisations = {
     en: 'Italian',
     es: 'Italiano',
     it: 'Italiano',
-    nl: 'Italiaans'
+    nl: 'Italiaans',
+    pl: 'Włoski',
+    hb: ''
   },
   LANGUAGE_GERMAN: {
     da: 'Tysk',
@@ -423,7 +539,9 @@ export const Localisations = {
     en: 'German',
     es: 'Alemán',
     it: 'Tedesco',
-    nl: 'Duits'
+    nl: 'Duits',
+    pl: 'Nimiecki',
+    hb: ''
   },
   LANGUAGE_DANISH: {
     da: 'Dansk',
@@ -431,7 +549,9 @@ export const Localisations = {
     en: 'Danish',
     es: 'Danés',
     it: 'Danese',
-    nl: 'Deens'
+    nl: 'Deens',
+    pl: 'Duński',
+    hb: ''
   },
   LANGUAGE_DUTCH: {
     da: 'Hollandsk',
@@ -439,7 +559,9 @@ export const Localisations = {
     en: 'Dutch',
     es: 'Holandés',
     it: 'Olandese',
-    nl: 'Nederlands'
+    nl: 'Nederlands',
+    pl: '',
+    hb: ''
   },
   BTN_ENROL_ENROL: {
     da: 'Registrering',
@@ -447,7 +569,9 @@ export const Localisations = {
     en: 'Enrol',
     es: 'Registro',
     it: 'Registrazione',
-    nl: 'Registreren'
+    nl: 'Registreren',
+    pl: 'Holenderski (niderlandzki)',
+    hb: ''
   },
   BTN_ENROL_SCAN: {
     da: 'Scan',
@@ -455,7 +579,9 @@ export const Localisations = {
     en: 'Scan',
     es: 'Escanear',
     it: 'Scansione',
-    nl: 'Scan'
+    nl: 'Scan',
+    pl: 'Skanuj',
+    hb: ''
   },
   BTN_ENROL_ENTER_TOKEN: {
     da: 'Indtast Token',
@@ -463,7 +589,9 @@ export const Localisations = {
     en: 'Enter Token',
     es: 'Ingresar Token',
     it: 'Inserisci Il Token',
-    nl: 'Token Invoeren'
+    nl: 'Token Invoeren',
+    pl: 'Wprowadź Token',
+    hb: ''
   },
   BTN_SUBMIT: {
     da: 'Indsend',
@@ -471,7 +599,9 @@ export const Localisations = {
     en: 'Submit',
     es: 'Enviar',
     it: 'Sottoscrivi',
-    nl: 'Voorleggen'
+    nl: 'Voorleggen',
+    pl: 'Zapisz',
+    hb: ''
   },
   BTN_FINISH: {
     da: 'Afslut',
@@ -479,7 +609,9 @@ export const Localisations = {
     en: 'Finish',
     es: 'Finalizar',
     it: 'Fine',
-    nl: 'Voltooid'
+    nl: 'Voltooid',
+    pl: 'Zakończ',
+    hb: ''
   },
   BTN_DONE: {
     da: 'Færdig',
@@ -487,7 +619,9 @@ export const Localisations = {
     en: 'Done',
     es: 'Completar',
     it: 'Fatto',
-    nl: 'Klaar'
+    nl: 'Klaar',
+    pl: 'Gotowe',
+    hb: ''
   },
   BTN_START: {
     da: 'Start',
@@ -495,7 +629,9 @@ export const Localisations = {
     en: 'Start',
     es: 'Inicio',
     it: 'Inizio',
-    nl: 'Begin'
+    nl: 'Begin',
+    pl: 'Start',
+    hb: ''
   },
   BTN_STOP: {
     da: 'Stoppe',
@@ -503,7 +639,9 @@ export const Localisations = {
     en: 'Stop',
     es: 'Detener',
     it: 'Fermare',
-    nl: 'Stoppen'
+    nl: 'Stoppen',
+    pl: 'Stop',
+    hb: ''
   },
   BTN_RESET: {
     da: 'Nulstil',
@@ -511,7 +649,9 @@ export const Localisations = {
     en: 'Reset',
     es: 'Restablecer',
     it: 'Reset',
-    nl: 'Reset'
+    nl: 'Reset',
+    pl: 'Reset',
+    hb: ''
   },
   BTN_RETRY: {
     da: 'Prøve igen',
@@ -519,7 +659,9 @@ export const Localisations = {
     en: 'Retry',
     es: 'REintentar',
     it: 'Riprovare',
-    nl: 'Probeer opnieuw'
+    nl: 'Probeer opnieuw',
+    pl: '',
+    hb: ''
   },
   BTN_AGREE: {
     da: 'Enig.',
@@ -527,7 +669,9 @@ export const Localisations = {
     en: 'Agree',
     es: 'Aceptar',
     it: 'Accetto',
-    nl: 'Akkoord'
+    nl: 'Akkoord',
+    pl: 'Zgadzam się',
+    hb: ''
   },
   BTN_DISAGREE: {
     da: 'Uenig',
@@ -535,7 +679,9 @@ export const Localisations = {
     en: 'Disagree',
     es: 'No aceptar',
     it: 'Non accetto',
-    nl: 'Niet akkoord'
+    nl: 'Niet akkoord',
+    pl: 'Nie zgadzam się',
+    hb: ''
   },
   BTN_OKAY: {
     da: 'Okay',
@@ -543,7 +689,9 @@ export const Localisations = {
     en: 'Okay',
     es: 'De acuerdo',
     it: 'Okay',
-    nl: 'OK'
+    nl: 'OK',
+    pl: '',
+    hb: ''
   },
   BTN_SET: {
     da: 'Indstil',
@@ -551,7 +699,9 @@ export const Localisations = {
     en: 'Set',
     es: 'Conjunto',
     it: 'Set',
-    nl: 'Set'
+    nl: 'Set',
+    pl: 'Ok',
+    hb: ''
   },
   BTN_CANCEL: {
     da: 'Afbryd',
@@ -559,7 +709,9 @@ export const Localisations = {
     en: 'Cancel',
     es: 'Suprimir',
     it: 'Elimina',
-    nl: 'Annuleren'
+    nl: 'Annuleren',
+    pl: 'Anuluj',
+    hb: ''
   },
   BTN_BEGIN: {
     da: 'Begynd',
@@ -567,7 +719,9 @@ export const Localisations = {
     en: 'Begin',
     es: 'Inicio',
     it: 'Inizio',
-    nl: 'Starten'
+    nl: 'Starten',
+    pl: 'Zacznij',
+    hb: ''
   },
   BTN_NEXT: {
     da: 'Næste',
@@ -575,7 +729,9 @@ export const Localisations = {
     en: 'Next',
     es: 'Siguiente',
     it: 'Successivo',
-    nl: 'Volgende'
+    nl: 'Volgende',
+    pl: 'Następny',
+    hb: ''
   },
   BTN_PREVIOUS: {
     da: 'Forrige',
@@ -583,7 +739,9 @@ export const Localisations = {
     en: 'Previous',
     es: 'Anterior',
     it: 'Precedente',
-    nl: 'Vorige'
+    nl: 'Vorige',
+    pl: 'Poprzedni',
+    hb: ''
   },
   BTN_CLOSE: {
     da: 'Luk',
@@ -591,7 +749,9 @@ export const Localisations = {
     en: 'Close',
     es: 'Cerrar',
     it: 'Chiudi',
-    nl: 'Sluiten'
+    nl: 'Sluiten',
+    pl: 'Zamknij',
+    hb: ''
   },
   BTN_SELECT: {
     da: 'Vælg',
@@ -599,7 +759,9 @@ export const Localisations = {
     en: 'Select',
     es: 'Seleccione',
     it: 'Seleziona',
-    nl: 'Selecteren'
+    nl: 'Selecteren',
+    pl: 'Wybierz',
+    hb: ''
   },
   BTN_YES: {
     da: 'Ja',
@@ -607,7 +769,9 @@ export const Localisations = {
     en: 'Yes',
     es: 'Sí',
     it: 'sì',
-    nl: 'Ja'
+    nl: 'Ja',
+    pl: 'Tak',
+    hb: ''
   },
   BTN_NO: {
     da: 'Ingen',
@@ -615,7 +779,9 @@ export const Localisations = {
     en: 'No',
     es: 'No',
     it: 'No',
-    nl: 'Nee'
+    nl: 'Nee',
+    pl: 'Nie',
+    hb: ''
   },
   BTN_TRY_AGAIN: {
     da: 'Prøv igen',
@@ -623,7 +789,9 @@ export const Localisations = {
     en: 'Try again',
     es: 'Inténtalo de nuevo',
     it: 'Riprova',
-    nl: 'Probeer het opnieuw'
+    nl: 'Probeer het opnieuw',
+    pl: 'Spróbuj ponownie',
+    hb: ''
   },
   STATUS_LOADING: {
     da: 'Indlæser',
@@ -631,7 +799,9 @@ export const Localisations = {
     en: 'Loading',
     es: 'Cargando',
     it: 'Caricamento',
-    nl: 'Laden'
+    nl: 'Laden',
+    pl: 'Ładowanie…',
+    hb: ''
   },
   STATUS_SUCCESS: {
     da: 'Succes',
@@ -639,7 +809,9 @@ export const Localisations = {
     en: 'Success',
     es: 'Completado',
     it: 'Successo',
-    nl: 'Geslaagd'
+    nl: 'Geslaagd',
+    pl: 'Sukces',
+    hb: ''
   },
   STATUS_NOW: {
     da: 'nu',
@@ -647,7 +819,9 @@ export const Localisations = {
     en: 'now',
     es: 'ahora',
     it: 'ora',
-    nl: 'nu'
+    nl: 'nu',
+    pl: 'teraz',
+    hb: ''
   },
   STATUS_FAILURE: {
     da: 'Fejl',
@@ -655,7 +829,9 @@ export const Localisations = {
     en: 'Failed',
     es: 'Error',
     it: 'Non riuscuto',
-    nl: 'Mislukt'
+    nl: 'Mislukt',
+    pl: 'NIe udało się',
+    hb: ''
   },
   NOTIFICATION_TEST_REMINDER_NOW: {
     da: 'Testmeddelelse',
@@ -663,7 +839,9 @@ export const Localisations = {
     en: 'Test Notification',
     es: 'Notificación de prueba',
     it: 'Notifica di prova',
-    nl: 'Testmelding'
+    nl: 'Testmelding',
+    pl: '',
+    hb: ''
   },
   NOTIFICATION_TEST_REMINDER_NOW_DESC: {
     da: 'Dette er en test anmeldelse.',
@@ -671,7 +849,9 @@ export const Localisations = {
     en: 'This is a test notification.',
     es: 'Esta es una notificación de prueba.',
     it: 'Questa è una notifica di prova.',
-    nl: 'Dit is een testmelding.'
+    nl: 'Dit is een testmelding.',
+    pl: 'Sprawdź powiadomienia',
+    hb: ''
   },
   NOTIFICATION_REMINDER_SOON: {
     da:
@@ -680,21 +860,34 @@ export const Localisations = {
       'Der RADAR-CNS Fragebogen muss morgen ausgefüllt werden – bitte denken Sie daran.',
     en:
       'RADAR-CNS questionnaire needs to be completed tomorrow – please remember.',
-    es: 'Recuerde que mañana tendrá que completar el cuestionario RADAR-CNS.',
-    it: 'Ti ricordiamo che domani dovrai compilare il questionario RADAR-CNS.',
+    es: 
+      'Recuerde que mañana tendrá que completar el cuestionario RADAR-CNS.',
+    it: 
+      'Ti ricordiamo che domani dovrai compilare il questionario RADAR-CNS.',
     nl:
-      'Vergeet u s.v.p. niet om de RADAR-CNS vragenlijst uiterlijk morgen in te vullen?'
+      'Vergeet u s.v.p. niet om de RADAR-CNS vragenlijst uiterlijk morgen in te vullen?',
+    pl: 
+      'Ankietę RADAR-CNS powinieneś wypełnić jutro – prosimy pamiętaj',
+    hb: 
+      ''  
   },
   NOTIFICATION_REMINDER_SOON_DESC: {
-    da: 'Husk at sætte lidt tid af i morgen, til at svare på et par spørgsmål.',
-    de: 'Denken Sie daran, morgen etwas Zeit für ein paar Fragebögen zu haben.',
-    en: 'Remember to put some time aside for a few questionnaires tomorrow.',
+    da: 
+      'Husk at sætte lidt tid af i morgen, til at svare på et par spørgsmål.',
+    de: 
+      'Denken Sie daran, morgen etwas Zeit für ein paar Fragebögen zu haben.',
+    en: 
+      'Remember to put some time aside for a few questionnaires tomorrow.',
     es:
       'Recuerde reservarse el tiempo mañana para contestar algunos cuestionarios',
     it:
       'Domani ricordati di lasciare del tempo libero per rispondere a brevi questionari.',
     nl:
-      'Vergeet u niet om morgen wat tijd vrij te maken voor het invullen van enkele vragenlijsten?'
+      'Vergeet u niet om morgen wat tijd vrij te maken voor het invullen van enkele vragenlijsten?',
+    pl: 
+      'Pamiętaj, by jutro zachować trochę czasu na wypełnienie ankiety.',
+    hb: 
+      ''  
   },
   NOTIFICATION_REMINDER_NOW: {
     da: 'Tid til at svare på spørgsmål',
@@ -702,7 +895,9 @@ export const Localisations = {
     en: 'Questionnaire time',
     es: 'Momento para el cuestionario ',
     it: "E' il momento dei questionari",
-    nl: 'Tijd voor een vragenlijst'
+    nl: 'Tijd voor een vragenlijst',
+    pl: 'Czas na ankietę',
+    hb: ''
   },
   NOTIFICATION_REMINDER_NOW_DESC_1: {
     da: 'Det tager normalt ikke længere end',
@@ -710,7 +905,9 @@ export const Localisations = {
     en: "Won't usually take longer than",
     es: 'No le llevará más tiempo de ',
     it: 'Non richiederanno più di',
-    nl: 'Meestal duurt dit niet langer dan'
+    nl: 'Meestal duurt dit niet langer dan',
+    pl: 'Zwykle nie zajmuje więcej niż',
+    hb: ''
   },
   NOTIFICATION_REMINDER_NOW_DESC_2: {
     da: 'minutter',
@@ -718,7 +915,9 @@ export const Localisations = {
     en: 'minutes.',
     es: 'minutos',
     it: 'minuti.',
-    nl: 'minuten.'
+    nl: 'minuten.',
+    pl: 'minut',
+    hb: ''
   },
   NOTIFICATION_REMINDER_FORGOTTEN: {
     da: 'Du mangler at svare på spørgsmål',
@@ -726,7 +925,9 @@ export const Localisations = {
     en: 'Missed a questionnaire?',
     es: '¿Ha olvidado algún cuestionario?',
     it: 'Hai dimenticato un questionario?',
-    nl: 'Heeft u een vragenlijst vergeten?'
+    nl: 'Heeft u een vragenlijst vergeten?',
+    pl: 'Pominąłeś ankietę?',
+    hb: ''
   },
   NOTIFICATION_REMINDER_FORGOTTEN_DESC: {
     da:
@@ -740,7 +941,11 @@ export const Localisations = {
     it:
       'Sembra che ti sia dimenticato di rispondere ad alcune domande. Puoi farlo ora?',
     nl:
-      'Het lijkt erop dat u niet alle vragen heeft beantwoord. Zou u dit nu alsnog willen doen?'
+      'Het lijkt erop dat u niet alle vragen heeft beantwoord. Zou u dit nu alsnog willen doen?',
+    pl: 
+      'Wygląda na to, że nie odpowiedziałeś na wszystkie pytania. Czy mógłbyś zrobić to teraz?',
+    hb: 
+      ''  
   },
   NOTIFICATION_REMINDER_FORGOTTEN_ALERT_DEFAULT_DESC: {
     da:
@@ -754,16 +959,29 @@ export const Localisations = {
     it:
       'Hai perso questo. Non preoccuparti! Il prossimo quesionario sarà presto disponibile.',
     nl:
-      'Je hebt deze gemist. Maak je geen zorgen! De volgende vragenlijst zal binnenkort verschijnen.'
+      'Je hebt deze gemist. Maak je geen zorgen! De volgende vragenlijst zal binnenkort verschijnen.',
+    pl: 
+      'Pominąłeś to pytanie. Nie przejmuj się! Następna ankieta będzie dostępna wkrótce.',
+    hb: 
+      ''  
   },
   NOTIFICATION_REMINDER_FORGOTTEN_ALERT_LASTOFNIGHT_DESC: {
     da:
       'Du har ikke nået at svare på sidste spørgsmål. Ingen problemer! Hav en god aften.',
-    de: 'Du hast den letzten verpasst. Mach dir keine Sorgen! Gute Nacht.',
-    en: "You've missed the last one. Dont worry! Have a good night.",
-    es: 'No ha llegado a contestar el último. No se preocupe! Buenas noches!',
-    it: "Hai perso l'ultimo. Non preoccuparti! Buonanotte.",
-    nl: 'Je hebt de laatste gemist. Maak je geen zorgen! Goede nacht.'
+    de: 
+      'Du hast den letzten verpasst. Mach dir keine Sorgen! Gute Nacht.',
+    en: 
+      "You've missed the last one. Dont worry! Have a good night.",
+    es: 
+      'No ha llegado a contestar el último. No se preocupe! Buenas noches!',
+    it: 
+      "Hai perso l'ultimo. Non preoccuparti! Buonanotte.",
+    nl: 
+      'Je hebt de laatste gemist. Maak je geen zorgen! Goede nacht.',
+    pl: 
+      'Pominąłeś ostatnie pytanie. Nie przejmuj się! Dobranoc.',
+    hb: 
+      ''
   },
   MEASURE_PROGRESS: {
     da: 'Fremgang',
@@ -771,7 +989,9 @@ export const Localisations = {
     en: 'Progress',
     es: 'Progreso',
     it: 'Progresso',
-    nl: 'Voortgang'
+    nl: 'Voortgang',
+    pl: 'Postęp',
+    hb: ''
   },
   MEASURE_STEPS: {
     da: 'Skridt',
@@ -779,7 +999,9 @@ export const Localisations = {
     en: 'Steps',
     es: 'Pasos',
     it: 'Passi',
-    nl: 'Stappen'
+    nl: 'Stappen',
+    pl: 'Kroki',
+    hb: ''
   },
   MEASURE_HEART_RATE: {
     da: 'Hjerterytme',
@@ -787,7 +1009,9 @@ export const Localisations = {
     en: 'Heart rate',
     es: 'Ritmo cardíaco',
     it: 'Frequenza cardiaca',
-    nl: 'Hartslagfrequentie'
+    nl: 'Hartslagfrequentie',
+    pl: 'Tętno',
+    hb: ''
   },
   CREDITS_TITLE: {
     da: 'Anerkendelser',
@@ -795,20 +1019,27 @@ export const Localisations = {
     en: 'Credits',
     es: 'Créditos',
     it: 'Crediti',
-    nl: 'Credits'
+    nl: 'Credits',
+    pl: 'Punkty',
+    hb: ''
   },
   CREDITS_BODY: {
     da:
-      'Lavet med &hearts; til dig af RADAR-Base-samfundet. For mere information click <a href="http://radar-base.org">her</a>.',
+      "Lavet med &hearts; til dig af RADAR-Base-samfundet. For mere information click <a href='http://radar-base.org'>her</a>.",
     de:
-      'Von der RADAR-Base-Community gemacht mit &hearts; für Sie gemacht. Für weitere Informationen klicken Sie <a href="http://radar-base.org">hier</a>',
+      "Von der RADAR-Base-Community gemacht mit &hearts; für Sie gemacht. Für weitere Informationen klicken Sie <a href='http://radar-base.org'>hier</a>.",
     en:
-      'Made with &hearts; for you by the RADAR-Base community. For more information click <a href="http://radar-base.org">here</a>.',
+      "Made with &hearts; for you by the RADAR-Base community. For more information click <a href='http://radar-base.org'>here</a>.",
     es:
-      'Hecho con &hearts;  para usted por la comunidad RADAR-Base. Para obtener más información, haga clic  en <a href="http://radar-base.org">aquí</a>.',
-    it: `Fatto con il &hearts; per te dalla comunità RADAR-Base. Per maggiori informazioni clicca <a href="http://radar-base.org">qui</a>.`,
+      "Hecho con &hearts;  para usted por la comunidad RADAR-Base. Para obtener más información, haga clic  en <a href='http://radar-base.org'>aquí</a>.",
+    it: 
+      "Fatto con il &hearts; per te dalla comunità RADAR-Base. Per maggiori informazioni clicca <a href='http://radar-base.org'>qui</a>.",
     nl:
-      'Met &hearts; voor u gemaakt door de RADAR-Base community. Voor meer informatie klik <a href="http://radar-base.org">here</a>'
+      "Met &hearts; voor u gemaakt door de RADAR-Base community. Voor meer informatie klik <a href='http://radar-base.org'>here</a>.",
+    pl: 
+      "przygotowane dla Ciebie przez RADAR-CNS. Aby uzyskać więcej informacji kliknij <a href='http://radar-base.org'>aquí</a>.",
+    hb: 
+      ""  
   },
   TASK_CALENDAR_TITLE: {
     da: 'Dagens opgaver',
@@ -816,7 +1047,9 @@ export const Localisations = {
     en: "Today's tasks",
     es: 'Las tareas de hoy',
     it: 'Le attività di oggi',
-    nl: 'Taken voor vandaag'
+    nl: 'Taken voor vandaag',
+    pl: 'Zadania na dziś',
+    hb: ''
   },
   TASK_INFO_WARN: {
     da: 'Kræver rolige omgivelser',
@@ -824,7 +1057,9 @@ export const Localisations = {
     en: 'Requires a quiet space',
     es: 'Requiere un espacio tranquilo',
     it: 'Richiede un posto tranquillo',
-    nl: 'Vereist een rustige omgeving'
+    nl: 'Vereist een rustige omgeving',
+    pl: 'Wymaga cichego otoczenia',
+    hb: ''
   },
   TASK_PROGRESS_TITLE: {
     da: 'I dag',
@@ -832,7 +1067,9 @@ export const Localisations = {
     en: 'Today',
     es: 'Hoy',
     it: 'Oggi',
-    nl: 'Vandaag'
+    nl: 'Vandaag',
+    pl: 'Dziś',
+    hb: ''
   },
   TASK_PROGRESS_COMPLETED: {
     da: 'Gennemført',
@@ -840,7 +1077,9 @@ export const Localisations = {
     en: 'Completed',
     es: 'Completado',
     it: 'Completato',
-    nl: 'Voltooid'
+    nl: 'Voltooid',
+    pl: 'Ukończone',
+    hb: ''
   },
   TASK_BAR_NEXT_TASK: {
     da: 'Din næste opgave starter om ',
@@ -848,7 +1087,9 @@ export const Localisations = {
     en: 'Your next task starts in ',
     es: 'La siguiente tarea comienza en ',
     it: 'La prossima attività inizierà tra ',
-    nl: 'Uw volgende taak start over '
+    nl: 'Uw volgende taak start over ',
+    pl: 'Następne zadanie zacznie się za',
+    hb: ''
   },
   TASK_BAR_NOW_TASK: {
     da: 'Din opgave starter ',
@@ -856,7 +1097,9 @@ export const Localisations = {
     en: 'Your task starts ',
     es: 'La tarea comienza ',
     it: 'Il tuo compito inizia ',
-    nl: 'Je taak begint '
+    nl: 'Je taak begint ',
+    pl: 'Twoje zadanie zacznie się',
+    hb: ''
   },
   TASK_BAR_NEXT_TASK_SOON: {
     da: 'snart',
@@ -864,7 +1107,9 @@ export const Localisations = {
     en: 'soon',
     es: 'en breve',
     it: 'Presto',
-    nl: 'binnenkort'
+    nl: 'binnenkort',
+    pl: 'niedługo',
+    hb: ''
   },
   TASK_BAR_AFFIRMATION_1: {
     da: 'Godt klaret!',
@@ -872,7 +1117,9 @@ export const Localisations = {
     en: 'Well done!',
     es: '¡Muy bien!',
     it: 'Ben fatto!',
-    nl: 'Goed gedaan!'
+    nl: 'Goed gedaan!',
+    pl: 'Gratulacje!',
+    hb: ''
   },
   TASK_BAR_AFFIRMATION_2: {
     da: 'Alle opgaver er gennemført.',
@@ -880,7 +1127,9 @@ export const Localisations = {
     en: 'All tasks completed.',
     es: 'Todas las tareas han sido completadas.',
     it: 'Tutte le attività sono state completate.',
-    nl: 'Alle taken voltooid.'
+    nl: 'Alle taken voltooid.',
+    pl: 'Wszystkie zadania ukończone.',
+    hb: ''
   },
   TASK_BAR_TASK_LEFT_1: {
     da: 'Vent venligst! ',
@@ -888,7 +1137,9 @@ export const Localisations = {
     en: 'Hold on! ',
     es: 'Espere! ',
     it: 'Resisti! ',
-    nl: 'Wacht! '
+    nl: 'Wacht! ',
+    pl: 'Czekaj!',
+    hb: ''
   },
   TASK_BAR_TASK_LEFT_2: {
     da: 'Der er stadig et par spørgsmål tilbage',
@@ -896,7 +1147,9 @@ export const Localisations = {
     en: 'A few questionnaires are still left.',
     es: 'Todavía quedan algunos cuestionarios',
     it: 'Mancano ancora pochi questionari',
-    nl: 'Er staan nog een paar vragenlijsten open'
+    nl: 'Er staan nog een paar vragenlijsten open',
+    pl: 'Zostało jeszcze kilka ankiet.',
+    hb: ''
   },
   TASK_BAR_NO_TASK_1: {
     da: 'Tag det roligt!',
@@ -904,7 +1157,9 @@ export const Localisations = {
     en: 'Relax!',
     es: '¡Relajese!',
     it: 'Relax!',
-    nl: 'Ontspan!'
+    nl: 'Ontspan!',
+    pl: 'Spokojnie!',
+    hb: ''
   },
   TASK_BAR_NO_TASK_2: {
     da: 'Der er ingen opgaver I dag.',
@@ -912,7 +1167,9 @@ export const Localisations = {
     en: 'No tasks today.',
     es: 'No tiene tareas para hoy',
     it: 'Nessuna attività oggi.',
-    nl: 'Geen taken vandaag.'
+    nl: 'Geen taken vandaag.',
+    pl: 'Na dziś nie ma żadnych zadań.',
+    hb: ''
   },
   TASK_TIME_HOUR_SINGLE: {
     da: 'time',
@@ -920,7 +1177,9 @@ export const Localisations = {
     en: 'hr',
     es: 'hora',
     it: 'ora',
-    nl: 'uur'
+    nl: 'uur',
+    pl: 'godz.',
+    hb: ''
   },
   TASK_TIME_HOUR_MULTIPLE: {
     da: 'timer',
@@ -928,7 +1187,9 @@ export const Localisations = {
     en: 'hrs',
     es: 'horas',
     it: 'ore',
-    nl: 'uren'
+    nl: 'uren',
+    pl: 'godz.',
+    hb: ''
   },
   TASK_TIME_MINUTE_SINGLE: {
     da: 'minut',
@@ -936,7 +1197,9 @@ export const Localisations = {
     en: 'min',
     es: 'minuto',
     it: 'minuto',
-    nl: 'minuut'
+    nl: 'minuut',
+    pl: 'min.',
+    hb: ''
   },
   TASK_TIME_MINUTE_MULTIPLE: {
     da: 'minutter',
@@ -944,7 +1207,9 @@ export const Localisations = {
     en: 'mins',
     es: 'minutos',
     it: 'minuti',
-    nl: 'minuten'
+    nl: 'minuten',
+    pl: 'min.',
+    hb: ''
   },
   TESTING_NOTIFICATIONS: {
     da: 'Testmeddelelser',
@@ -952,17 +1217,27 @@ export const Localisations = {
     en: 'Testing Notifications',
     es: 'Pruebas de Notificaciones',
     it: 'Test delle Notifiche',
-    nl: 'Testen van Meldingen'
+    nl: 'Testen van Meldingen',
+    pl: 'Powiadomienia testowe',
+    hb: ''
   },
   TESTING_NOTIFICATIONS_MESSAGE: {
-    da: 'Luk nu appen og vent i 2 minutter for testmeddelelsen.',
+    da: 
+      'Luk nu appen og vent i 2 minutter for testmeddelelsen.',
     de:
       'Schließen Sie nun die App und warten Sie 2 Minuten auf die Testbenachrichtigung.',
-    en: 'Now close the app and wait for 2 minutes for the test notification.',
+    en: 
+      'Now close the app and wait for 2 minutes for the test notification.',
     es:
       'Ahora cierre la aplicación y espere 2 minutos para la notificación de prueba.',
-    it: "Ora chiudi l'app e attendi 2 minuti per la notifica del test.",
-    nl: 'Sluit nu de app en wacht 2 minuten op de testmelding.'
+    it: 
+      "Ora chiudi l'app e attendi 2 minuti per la notifica del test.",
+    nl: 
+      'Sluit nu de app en wacht 2 minuten op de testmelding.',
+    pl: 
+      'Zamknij aplikację i poczekaj 2 minuty na powiadomienie testowe',
+    hb: 
+      ''
   },
   CLOSE_APP: {
     da: 'Luk App',
@@ -970,15 +1245,19 @@ export const Localisations = {
     en: 'Close App',
     es: 'Cierre App',
     it: 'Chiudi App',
-    nl: 'App Sluiten'
+    nl: 'App Sluiten',
+    pl: 'Zamknij aplikację',
+    hb: ''
   },
   WARNING_DO_NOT_CLOSE_APP: {
     da: 'Luk ikke appen',
     de: 'Schließen Sie die App nicht',
     en: 'Do not close the app',
     es: 'No cierres la aplicación',
-    it: `Non chiudere l'app`,
-    nl: 'Sluit de app niet'
+    it: "Non chiudere l'app",
+    nl: 'Sluit de app niet',
+    pl: 'Nie zamykaj aplikacji',
+    hb: ''
   },
   AUDIO_TASK_ALERT: {
     da: 'Lydopgave afbrudt',
@@ -986,15 +1265,19 @@ export const Localisations = {
     en: 'Audio task interrupted',
     es: 'Tarea de audio interrumpida',
     it: 'Attività audio interrotta',
-    nl: 'Audiotaak onderbroken'
+    nl: 'Audiotaak onderbroken',
+    pl: 'Zadanie audio przerwane',
+    hb: ''
   },
   AUDIO_TASK_ALERT_DESC: {
     da: 'Opgaven er afbrudt. Genstart opgaven.',
     de: 'Die Aufgabe wurde unterbrochen. Task neu starten.',
     en: 'Task has been interrupted. Restart task.',
     es: 'La tarea ha sido interrumpida. Tarea de reinicio.',
-    it: `L'attività è stata interrotta. Riavvia il compito.`,
-    nl: 'Taak is onderbroken. Start de taak opnieuw.'
+    it: "L'attività è stata interrotta. Riavvia il compito.",
+    nl: 'Taak is onderbroken. Start de taak opnieuw.',
+    pl: 'Zadanie zostało przerwane. Zacznij od nowa.',
+    hb: ''
   },
   AUDIO_TASK_ATTEMPT_ALERT: {
     da: 'Forsøg tilbageværende',
@@ -1002,7 +1285,9 @@ export const Localisations = {
     en: 'Attempts remaining',
     es: 'Intentos restantes',
     it: 'Tentativi rimanenti',
-    nl: 'Pogingen blijven'
+    nl: 'Pogingen blijven',
+    pl: 'Pozostało prób',
+    hb: ''
   },
   AUDIO_TASK_HAPPY_ALERT: {
     da: 'Indsend optagelse?',
@@ -1010,15 +1295,19 @@ export const Localisations = {
     en: 'Submit recording?',
     es: '¿Enviar grabación?',
     it: 'Invia la registrazione?',
-    nl: 'Opname verzenden?'
+    nl: 'Opname verzenden?',
+    pl: 'Dodaj nagranie',
+    hb: ''
   },
   CONFIG_ERROR_DESC: {
     da: 'Config opdatering mislykkes. Prøve igen?',
     de: 'Config Update fehlgeschlagen. Wiederholen?',
     en: 'Config update fail. Retry?',
     es: 'La actualización de configuración falla. ¿Procesar de nuevo?',
-    it: `Errore nell'aggiornamento della configurazione. Riprovare?`,
-    nl: 'Config-update mislukt. Opnieuw?'
+    it: "Errore nell'aggiornamento della configurazione. Riprovare?",
+    nl: 'Config-update mislukt. Opnieuw?',
+    pl: 'Nieudana konfiguracja akutualizacji. Powtórzyć?',
+    hb: ''
   },
   SPLASH_STATUS_UPDATING_CONFIG: {
     da: 'Opdaterer underretninger og planlæg...',
@@ -1026,7 +1315,9 @@ export const Localisations = {
     en: 'Updating notifications and schedule...',
     es: 'Actualizando notificaciones y programa...',
     it: 'Aggiornamento notifiche e pianificazione...',
-    nl: 'Meldingen en planning bijwerken...'
+    nl: 'Meldingen en planning bijwerken...',
+    pl: '',
+    hb: ''
   },
   SPLASH_STATUS_SENDING_LOGS: {
     da: 'Afsendelse af ubesvarede spørgeskemaer...',
@@ -1034,6 +1325,8 @@ export const Localisations = {
     en: 'Sending missed questionnaire logs...',
     es: 'Enviando registros de cuestionarios perdidos...',
     it: 'Invio dei registri dei questionari persi ...',
-    nl: 'Logboeken gemiste vragenlijst verzenden...'
+    nl: 'Logboeken gemiste vragenlijst verzenden...',
+    pl: '',
+    hb: ''
   }
 }

--- a/src/assets/data/localisations.ts
+++ b/src/assets/data/localisations.ts
@@ -18,7 +18,7 @@ export const Localisations = {
     it: 'Benvenuto',
     nl: 'Welkom',
     pl: 'Witamy',
-    hb: ''
+    hb: 'ברוכים הבאים'
   },
   ENROL_WELCOME_2: {
     da: 'til RADAR-Base',
@@ -28,7 +28,7 @@ export const Localisations = {
     it: 'in RADAR-Base',
     nl: 'bij RADAR-Base',
     pl: 'w RADAR-CNS',
-    hb: ''
+    hb: 'RADAR-CNS-ל'
   },
   ENROL_WELCOME_DESC: {
     da:
@@ -46,7 +46,7 @@ export const Localisations = {
     pl: 
       'Dziękujemy za wzięcie udziału w badaniu. Przejdź przez proces rejestracji, byś mógł zacząć korzystać z aplikacji',
     hb: 
-      ''  
+      '.תודה שאתם משתתף במחקר זה. בוא נתחיל את הליך ההרשמה באפליקציה'  
   },
   ENROL_REGISTRATION: {
     da: 'Registrering',
@@ -56,7 +56,7 @@ export const Localisations = {
     it: 'Registrazione',
     nl: 'Registratie',
     pl: 'Rejestracja',
-    hb: ''
+    hb: 'הרשמה'
   },
   ENROL_REGISTRATION_DESC: {
     da:
@@ -74,7 +74,7 @@ export const Localisations = {
     pl: 
       'Zanim będziesz mógł korzystać z aplikacji, musisz się zarejestrować. Możesz zeskanować kod QR lub wpisać Token',
     hb: 
-      ''  
+      'לפני שתוכל להתחיל להשתמש באפליקציה, אנחנו צריכים שתרשם אליה. תוכל לעשות זאת באמצעות קוד QR או הזנת טוקן'  
   },
   ENROL_REGISTRATION_SCAN_DESC: {
     da:
@@ -92,7 +92,7 @@ export const Localisations = {
     pl: 
       "Kliknij przycisk Skanuj i skieruj aparat telefonu na kod QR, który otrzymałeś od badacza. Przykładowy kod QR znajduje się poniżej.",
     hb: 
-      ""  
+      ".לחץ על כפתור הסריקה וכוון את הממלצה לקוד QR, שניתן לך מהחוקר. דוגמה לקוד QR מוצגת מטה"  
   },
   ENROL_REGISTRATION_TOKEN_DESC: {
     da:
@@ -110,7 +110,7 @@ export const Localisations = {
     pl: 
       'Wprowadź Token. Powinien być widoczny poniżej kodu QR w Mahagement Portal. Jeśli go tam nie znajdziesz, zeskanuj kod QR.',
     hb: 
-      ''  
+      'הזן את הטוקן. זה אמור להיות זמין לך תחת הקוד QR בפורטל ניהול. אם הוא לא זמין, בבקשה סרוק את הקוד QR.'  
   },
   ENROL_PREFERENCES: {
     da: 'Præferencer',
@@ -120,7 +120,7 @@ export const Localisations = {
     it: 'Preferenze',
     nl: 'Voorkeurs instellingen',
     pl: 'Preferencje',
-    hb: ''
+    hb: 'העדפות'
   },
   ENROL_PREFERENCES_DESC: {
     da:
@@ -138,7 +138,7 @@ export const Localisations = {
     pl: 
       'Co tydzień wyślemy Ci podsumowanie zebranych przez nas danych. Wybierz wszystkie tematy, na temat których chciałbyś uzyskiwać informacje.',
     hb: 
-      ''  
+      'נשלח לך סיכומים שבועיים על המידע שאתה שולח לנו. תרגיש חופשי לבחור כמה נושאים שתרצה לקבל עליהם מידע.'  
   },
   ENROL_REGISTRATION_COMPLETE: {
     da: 'Registrering Afsluttet',
@@ -148,7 +148,7 @@ export const Localisations = {
     it: 'Registrazione Completa',
     nl: 'Registratie Compleet',
     pl: 'Rejestracja zakończona',
-    hb: ''
+    hb: 'הרשמה הושלמה'
   },
   ENROL_REGISTRATION_COMPLETE_DESC: {
     da: "Du er nu med tilmelding til undersøgelsen. Klik på 'Afslut' for at begynde at generere din spørgeskemaplan og dine meddelelser.",
@@ -158,7 +158,7 @@ export const Localisations = {
     it: "Ora ti sei iscritto con successo allo studio. Fai clic su 'Fine' per iniziare a generare la pianificazione del questionario e le notifiche.",
     nl: "U bent nu succesvol ingeschreven voor het onderzoek. Klik op 'Voltooid' om uw vragenlijstschema en meldingen te genereren.",
     pl: 'Z powodzeniem zarejestrowałeś się w badaniu. Kliknij „Zakończone”, aby wygenerować harmonogram kwestionariusza i powiadomienia',
-    hb: ''
+    hb: '.נרשמת בהצלחה למחקר. לחץ על 'סיום' כדי להתחיל ליצור את לוח הזמנים וההודעות שלך'
   },
   FINISH_THANKS: {
     da: 'Tak fordi du udfyldte spørgeskemaet.',
@@ -168,7 +168,7 @@ export const Localisations = {
     it: 'Grazie per aver completato il questionario.',
     nl: 'Bedankt voor het invullen van de vragenlijst.',
     pl: 'Dziękujemy za wypełnienie ankiety.',
-    hb: ''
+    hb: '.תודה שמילאת את השאלון'
   },
   FINISH_NEXT_TASK_REMINDER: {
     da: 'Husk, du har stadig udestående opgaver!',
@@ -178,7 +178,7 @@ export const Localisations = {
     it: 'Ricorda, hai ancora delle attività in sospeso!',
     nl: 'Denk eraan, je hebt nog steeds taken openstaan!',
     pl: 'Pamiętaj, że zostały Ci jeszcze zadania do dokończenia!',
-    hb: ''
+    hb: 'זכור יש לך משימות לא גמורות'
   },
   FINISH_COMPLETED_IN_CLINIC: {
     da: 'Afsluttet i klinik?',
@@ -188,7 +188,7 @@ export const Localisations = {
     it: 'Completato in clinica?',
     nl: 'Voltooid in de kliniek?',
     pl: 'Ukończone w klinice',
-    hb: ''
+    hb: '?מילאת במרפאה'
   },
   CALENDAR_ESM_MISSED_TITLE: {
     da: 'Blokeret',
@@ -198,7 +198,7 @@ export const Localisations = {
     it: 'Bloccato',
     nl: 'Geblokkeerd',
     pl: 'Zablokowane',
-    hb: ''
+    hb: 'חסום'
   },
   CALENDAR_ESM_MISSED_DESC: {
     da: 'Spørgsmålet kan ikke besvares længere.',
@@ -215,7 +215,7 @@ export const Localisations = {
     pl: 
       'Niestety kwestionariusz można wypełniać tylko po otrzymaniu powiadomienia',
     hb: 
-      ''  
+      '.לצערנו, אתה יכול לענות על השאלון רק כשיש ההתראה'  
   },
   CLINICAL_TASKS: {
     da: 'Kliniske vurderinger',
@@ -225,7 +225,7 @@ export const Localisations = {
     it: 'Valutazioni cliniche',
     nl: 'Klinische beoordelingen',
     pl: 'Ocena kliniczna',
-    hb: ''
+    hb: 'הערכות קליניות'
   },
   SETTINGS_SETTINGS: {
     da: 'Indstillinger',
@@ -235,7 +235,7 @@ export const Localisations = {
     it: 'Impostazioni',
     nl: 'Instellingen',
     pl: 'Ustawienia',
-    hb: ''
+    hb: 'הגדרות'
   },
   SETTINGS_PARTICIPANTID: {
     da: 'Bruger ID',
@@ -245,7 +245,7 @@ export const Localisations = {
     it: 'ID utente',
     nl: 'Gebruikers ID',
     pl: 'ID użytkownika',
-    hb: ''
+    hb: 'שם משתמש'
   },
   SETTINGS_PROJECTNAME: {
     da: 'Projektnavn',
@@ -255,7 +255,7 @@ export const Localisations = {
     it: 'Nome del progetto',
     nl: 'Project naam',
     pl: 'Nazwa projektu',
-    hb: ''
+    hb: 'שם הפרויקט'
   },
   SETTINGS_USER_INFO: {
     da: 'Bruger information',
@@ -265,7 +265,7 @@ export const Localisations = {
     it: 'Informazioni utente',
     nl: 'Gebruikersinformatie',
     pl: 'Informacje o użytkowniku',
-    hb: ''
+    hb: 'מידע משתמש'
   },
   SETTINGS_ENROL_DATE: {
     da: 'Registreringsdata',
@@ -275,7 +275,7 @@ export const Localisations = {
     it: 'Data di arruolamento',
     nl: 'Datum van inclusie',
     pl: 'Data rejestracji',
-    hb: ''
+    hb: 'תאריך הרשמה'
   },
   SETTINGS_LANGUAGE: {
     da: 'Sprog',
@@ -285,7 +285,7 @@ export const Localisations = {
     it: 'Lingua',
     nl: 'Taal',
     pl: 'Język',
-    hb: ''
+    hb: 'שפה'
   },
   SETTINGS_LANGUAGE_ALERT: {
     da: 'Vælg dit sprog',
@@ -295,7 +295,7 @@ export const Localisations = {
     it: 'Seleziona la lingua desiderata',
     nl: 'Kies uw taal',
     pl: 'Wybierz język',
-    hb: ''
+    hb: 'בחר את השפה שלך'
   },
   SETTINGS_NOTIFICATIONS: {
     da: 'Notifikationer',
@@ -305,7 +305,7 @@ export const Localisations = {
     it: 'Notifiche',
     nl: 'Notificaties',
     pl: 'Powiadomienia',
-    hb: ''
+    hb: 'התראות'
   },
   SETTINGS_NOTIFICATIONS_SOUND: {
     da: 'Lyd',
@@ -315,7 +315,7 @@ export const Localisations = {
     it: 'Suoneria',
     nl: 'Geluid',
     pl: 'Dźwięk',
-    hb: ''
+    hb: 'צליל'
   },
   SETTINGS_NOTIFICATIONS_VIBRATION: {
     da: 'Vibration',
@@ -325,7 +325,7 @@ export const Localisations = {
     it: 'Vibrazione',
     nl: 'Trillen',
     pl: 'Wibracje',
-    hb: ''
+    hb: 'רטט'
   },
   SETTINGS_NOTIFICATIONS_NIGHTMOD: {
     da: 'Nattilstand',
@@ -335,7 +335,7 @@ export const Localisations = {
     it: 'Modalità notte',
     nl: 'Nachtmodus',
     pl: 'Tryb nocny',
-    hb: ''
+    hb: 'מצב לילה'
   },
   SETTINGS_NOTIFICATIONS_NIGHTMOD_DESC: {
     da: 
@@ -353,7 +353,7 @@ export const Localisations = {
     pl: 
       'Tryb nocny blokuje wszystkie powiadomienia między 22:00 a 07:30.',
     hb: 
-      ''
+      '.מצב לילה עוצר את כל ההתראות בין 22:00 ל- 7:30 למחרת'
   },
   SETTINGS_REPORT: {
     da: 'Ugentlig rapport',
@@ -363,7 +363,7 @@ export const Localisations = {
     it: 'Report settimanale',
     nl: 'Wekelijkse rapporten',
     pl: 'Raport tygodniowy',
-    hb: ''
+    hb: 'דו"חות שבועיים'
   },
   SETTINGS_VERSION: {
     da: 'Version',
@@ -373,7 +373,7 @@ export const Localisations = {
     it: 'Versione',
     nl: 'Versie',
     pl: 'Wersja',
-    hb: ''
+    hb: 'גרסה'
   },
   SETTINGS_CONFIGURATION: {
     da: 'Konfiguration',
@@ -383,7 +383,7 @@ export const Localisations = {
     it: 'Configurazione',
     nl: 'Configuratie',
     pl: 'Konfiguracja',
-    hb: ''
+    hb: 'קונפיגורציה'
   },
   SETTINGS_SCHEDULE: {
     da: 'Tidsplan',
@@ -393,7 +393,7 @@ export const Localisations = {
     it: 'Programma',
     nl: 'Schema',
     pl: 'Plan',
-    hb: ''
+    hb: 'לוּחַ זְמַנִים'
   },
   SETTINGS_RESET_ALERT: {
     da: 'Nulstil App',
@@ -403,7 +403,7 @@ export const Localisations = {
     it: 'Reset app',
     nl: 'Reset app',
     pl: 'Zresetuj aplikację',
-    hb: ''
+    hb: 'לאפס את היישום'
   },
   SETTINGS_RESET_ALERT_DESC: {
     da: 'Du er ved at nulstille appen.',
@@ -413,7 +413,7 @@ export const Localisations = {
     it: "Stai per ripristinare l'app.",
     nl: 'U staat op het punt de app opnieuw in te stellen.',
     pl: 'Masz zamiar zresetować aplikację',
-    hb: ''
+    hb: '.אתה עומד לאפס את האפליקציה'
   },
   SETTINGS_RESET_ALERT_OPTION_DESC: {
     da: 
@@ -431,7 +431,7 @@ export const Localisations = {
     pl:
       'wybierz tylko zresetować konfigurację i dane aplikacji lub wykonać pełny reset i ponownie zarejestrować',
     hb: 
-      ''
+      '.בחר לאפס את תצורת ונתוני האפליקציה בלבד או לבצע איפוס מלא ולהירשם מחדש'
   },
   SETTINGS_CACHE: {
     da: 'Cache',
@@ -441,7 +441,7 @@ export const Localisations = {
     it: 'Cache',
     nl: 'Cache',
     pl: 'Pamięć podręczna (cache)',
-    hb: ''
+    hb: 'מטמון'
   },
   SETTINGS_CACHE_SIZE: {
     da: 'Størrelse',
@@ -451,7 +451,7 @@ export const Localisations = {
     it: 'Dimensione',
     nl: 'Grootte',
     pl: 'Rozmiar',
-    hb: ''
+    hb: 'גודל'
   },
   SETTINGS_LAST_UPLOAD_TO_SERVER: {
     da: 'Sidste upload til server',
@@ -461,7 +461,7 @@ export const Localisations = {
     it: 'Ultimo caricamento sul server',
     nl: 'Laatste upload naar server',
     pl: 'Ostatnie wysyłanie na serwer',
-    hb: ''
+    hb: 'העלאה אחרונה לשרת'
   },
   SETTINGS_DEBUGGING: {
     da: 'Debugging',
@@ -471,7 +471,7 @@ export const Localisations = {
     it: 'Debug',
     nl: 'Debugging',
     pl: 'Debugowanie',
-    hb: ''
+    hb: 'מחפש באגים'
   },
   SETTINGS_GENERATE_NOTIFS: {
     da: 'Generer Testmeddelelse',
@@ -481,7 +481,7 @@ export const Localisations = {
     it: 'Genera Notifica di Prova',
     nl: 'Genereer Testmelding',
     pl: 'wygeneruj powiadomienie o badaniu',
-    hb: ''
+    hb: 'הפק התראות מבחן '
   },
   SETTINGS_LOG_NOTIFS: {
     da: 'Logmeddelelser',
@@ -491,7 +491,7 @@ export const Localisations = {
     it: 'Registra le Notifiche',
     nl: 'Logmeldingen',
     pl: 'Powiadomienia z dziennika',
-    hb: ''
+    hb: 'נעל התראות'
   },
   SETTINGS_SEND_CACHED_DATA: {
     da: 'Send Cachelagrede Data',
@@ -501,7 +501,7 @@ export const Localisations = {
     it: 'Invia Dati Memorizzati nella Cache',
     nl: 'Gegevens in Cache Verzenden',
     pl: 'Wyślij dane z pamięci podręcznej',
-    hb: ''
+    hb: 'שלח נתונים במטמון'
   },
   LANGUAGE_ENGLISH: {
     da: 'Engelsk',
@@ -511,7 +511,7 @@ export const Localisations = {
     it: 'Inglese',
     nl: 'Engels',
     pl: 'Angielski',
-    hb: ''
+    hb: 'אנגלית'
   },
   LANGUAGE_SPANISH: {
     da: 'Spansk',
@@ -521,7 +521,7 @@ export const Localisations = {
     it: 'Spagnolo',
     nl: 'Spaans',
     pl: 'Hiszpański',
-    hb: ''
+    hb: 'ספרדית'
   },
   LANGUAGE_ITALIAN: {
     da: 'Italiensk',
@@ -531,7 +531,7 @@ export const Localisations = {
     it: 'Italiano',
     nl: 'Italiaans',
     pl: 'Włoski',
-    hb: ''
+    hb: 'איטלקית'
   },
   LANGUAGE_GERMAN: {
     da: 'Tysk',
@@ -541,7 +541,7 @@ export const Localisations = {
     it: 'Tedesco',
     nl: 'Duits',
     pl: 'Nimiecki',
-    hb: ''
+    hb: 'גרמנית'
   },
   LANGUAGE_DANISH: {
     da: 'Dansk',
@@ -551,7 +551,7 @@ export const Localisations = {
     it: 'Danese',
     nl: 'Deens',
     pl: 'Duński',
-    hb: ''
+    hb: 'דנית'
   },
   LANGUAGE_DUTCH: {
     da: 'Hollandsk',
@@ -561,7 +561,7 @@ export const Localisations = {
     it: 'Olandese',
     nl: 'Nederlands',
     pl: 'Holenderski (niderlandzki)',
-    hb: ''
+    hb: 'הולנדית'
   },
   BTN_ENROL_ENROL: {
     da: 'Registrering',
@@ -571,7 +571,7 @@ export const Localisations = {
     it: 'Registrazione',
     nl: 'Registreren',
     pl: 'zarejestruj się',
-    hb: ''
+    hb: 'הירשם'
   },
   BTN_ENROL_SCAN: {
     da: 'Scan',
@@ -581,7 +581,7 @@ export const Localisations = {
     it: 'Scansione',
     nl: 'Scan',
     pl: 'Skanuj',
-    hb: ''
+    hb: 'סרוק'
   },
   BTN_ENROL_ENTER_TOKEN: {
     da: 'Indtast Token',
@@ -591,7 +591,7 @@ export const Localisations = {
     it: 'Inserisci Il Token',
     nl: 'Token Invoeren',
     pl: 'Wprowadź Token',
-    hb: ''
+    hb: 'הזן טוק'
   },
   BTN_SUBMIT: {
     da: 'Indsend',
@@ -601,7 +601,7 @@ export const Localisations = {
     it: 'Sottoscrivi',
     nl: 'Voorleggen',
     pl: 'Zapisz',
-    hb: ''
+    hb: 'שלח'
   },
   BTN_FINISH: {
     da: 'Afslut',
@@ -611,7 +611,7 @@ export const Localisations = {
     it: 'Fine',
     nl: 'Voltooid',
     pl: 'Zakończ',
-    hb: ''
+    hb: 'סיים'
   },
   BTN_DONE: {
     da: 'Færdig',
@@ -621,7 +621,7 @@ export const Localisations = {
     it: 'Fatto',
     nl: 'Klaar',
     pl: 'Gotowe',
-    hb: ''
+    hb: 'סיימתי'
   },
   BTN_START: {
     da: 'Start',
@@ -631,7 +631,7 @@ export const Localisations = {
     it: 'Inizio',
     nl: 'Begin',
     pl: 'Start',
-    hb: ''
+    hb: 'התחל'
   },
   BTN_STOP: {
     da: 'Stoppe',
@@ -641,7 +641,7 @@ export const Localisations = {
     it: 'Fermare',
     nl: 'Stoppen',
     pl: 'Stop',
-    hb: ''
+    hb: 'עצור'
   },
   BTN_RESET: {
     da: 'Nulstil',
@@ -651,7 +651,7 @@ export const Localisations = {
     it: 'Reset',
     nl: 'Reset',
     pl: 'Reset',
-    hb: ''
+    hb: 'אתחל מחדש'
   },
   BTN_RETRY: {
     da: 'Prøve igen',
@@ -661,7 +661,7 @@ export const Localisations = {
     it: 'Riprovare',
     nl: 'Probeer opnieuw',
     pl: 'Spróbuj ponownie',
-    hb: ''
+    hb: 'נסה שוב'
   },
   BTN_AGREE: {
     da: 'Enig.',
@@ -671,7 +671,7 @@ export const Localisations = {
     it: 'Accetto',
     nl: 'Akkoord',
     pl: 'Zgadzam się',
-    hb: ''
+    hb: 'מסכים'
   },
   BTN_DISAGREE: {
     da: 'Uenig',
@@ -681,7 +681,7 @@ export const Localisations = {
     it: 'Non accetto',
     nl: 'Niet akkoord',
     pl: 'Nie zgadzam się',
-    hb: ''
+    hb: 'לא מסכים'
   },
   BTN_OKAY: {
     da: 'Okay',
@@ -691,7 +691,7 @@ export const Localisations = {
     it: 'Okay',
     nl: 'OK',
     pl: 'OK',
-    hb: ''
+    hb: 'בסדר'
   },
   BTN_SET: {
     da: 'Indstil',
@@ -701,7 +701,7 @@ export const Localisations = {
     it: 'Set',
     nl: 'Set',
     pl: 'Ok',
-    hb: ''
+    hb: 'הגדר'
   },
   BTN_CANCEL: {
     da: 'Afbryd',
@@ -711,7 +711,7 @@ export const Localisations = {
     it: 'Elimina',
     nl: 'Annuleren',
     pl: 'Anuluj',
-    hb: ''
+    hb: 'בטל'
   },
   BTN_BEGIN: {
     da: 'Begynd',
@@ -721,7 +721,7 @@ export const Localisations = {
     it: 'Inizio',
     nl: 'Starten',
     pl: 'Zacznij',
-    hb: ''
+    hb: 'התחל'
   },
   BTN_NEXT: {
     da: 'Næste',
@@ -731,7 +731,7 @@ export const Localisations = {
     it: 'Successivo',
     nl: 'Volgende',
     pl: 'Następny',
-    hb: ''
+    hb: 'הבא'
   },
   BTN_PREVIOUS: {
     da: 'Forrige',
@@ -741,7 +741,7 @@ export const Localisations = {
     it: 'Precedente',
     nl: 'Vorige',
     pl: 'Poprzedni',
-    hb: ''
+    hb: 'הקודם'
   },
   BTN_CLOSE: {
     da: 'Luk',
@@ -751,7 +751,7 @@ export const Localisations = {
     it: 'Chiudi',
     nl: 'Sluiten',
     pl: 'Zamknij',
-    hb: ''
+    hb: 'סגור'
   },
   BTN_SELECT: {
     da: 'Vælg',
@@ -761,7 +761,7 @@ export const Localisations = {
     it: 'Seleziona',
     nl: 'Selecteren',
     pl: 'Wybierz',
-    hb: ''
+    hb: 'בחר'
   },
   BTN_YES: {
     da: 'Ja',
@@ -771,7 +771,7 @@ export const Localisations = {
     it: 'sì',
     nl: 'Ja',
     pl: 'Tak',
-    hb: ''
+    hb: 'כן'
   },
   BTN_NO: {
     da: 'Ingen',
@@ -781,7 +781,7 @@ export const Localisations = {
     it: 'No',
     nl: 'Nee',
     pl: 'Nie',
-    hb: ''
+    hb: 'לא'
   },
   BTN_TRY_AGAIN: {
     da: 'Prøv igen',
@@ -791,7 +791,7 @@ export const Localisations = {
     it: 'Riprova',
     nl: 'Probeer het opnieuw',
     pl: 'Spróbuj ponownie',
-    hb: ''
+    hb: 'נסה שוב'
   },
   STATUS_LOADING: {
     da: 'Indlæser',
@@ -801,7 +801,7 @@ export const Localisations = {
     it: 'Caricamento',
     nl: 'Laden',
     pl: 'Ładowanie…',
-    hb: ''
+    hb: 'טוען'
   },
   STATUS_SUCCESS: {
     da: 'Succes',
@@ -811,7 +811,7 @@ export const Localisations = {
     it: 'Successo',
     nl: 'Geslaagd',
     pl: 'Sukces',
-    hb: ''
+    hb: 'הצלחה'
   },
   STATUS_NOW: {
     da: 'nu',
@@ -821,7 +821,7 @@ export const Localisations = {
     it: 'ora',
     nl: 'nu',
     pl: 'teraz',
-    hb: ''
+    hb: 'עכשיו'
   },
   STATUS_FAILURE: {
     da: 'Fejl',
@@ -831,7 +831,7 @@ export const Localisations = {
     it: 'Non riuscuto',
     nl: 'Mislukt',
     pl: 'NIe udało się',
-    hb: ''
+    hb: 'נכשל'
   },
   NOTIFICATION_TEST_REMINDER_NOW: {
     da: 'Testmeddelelse',
@@ -841,7 +841,7 @@ export const Localisations = {
     it: 'Notifica di prova',
     nl: 'Testmelding',
     pl: 'powiadomienie o badaniu',
-    hb: ''
+    hb: 'בצע התראת מבח'
   },
   NOTIFICATION_TEST_REMINDER_NOW_DESC: {
     da: 'Dette er en test anmeldelse.',
@@ -851,7 +851,7 @@ export const Localisations = {
     it: 'Questa è una notifica di prova.',
     nl: 'Dit is een testmelding.',
     pl: 'Sprawdź powiadomienia',
-    hb: ''
+    hb: 'זאת התראת מבחן'
   },
   NOTIFICATION_REMINDER_SOON: {
     da:
@@ -869,7 +869,7 @@ export const Localisations = {
     pl: 
       'Ankietę RADAR-CNS powinieneś wypełnić jutro – prosimy pamiętaj',
     hb: 
-      ''  
+      'יש להשלים את שאלון RADAR-CNS מחר- נא לזכור'  
   },
   NOTIFICATION_REMINDER_SOON_DESC: {
     da: 
@@ -887,7 +887,7 @@ export const Localisations = {
     pl: 
       'Pamiętaj, by jutro zachować trochę czasu na wypełnienie ankiety.',
     hb: 
-      ''  
+      'תזכור לפנות קצת זמן להשלים שאלונים מחר'  
   },
   NOTIFICATION_REMINDER_NOW: {
     da: 'Tid til at svare på spørgsmål',
@@ -897,7 +897,7 @@ export const Localisations = {
     it: "E' il momento dei questionari",
     nl: 'Tijd voor een vragenlijst',
     pl: 'Czas na ankietę',
-    hb: ''
+    hb: 'זמן לשאלון'
   },
   NOTIFICATION_REMINDER_NOW_DESC_1: {
     da: 'Det tager normalt ikke længere end',
@@ -907,7 +907,7 @@ export const Localisations = {
     it: 'Non richiederanno più di',
     nl: 'Meestal duurt dit niet langer dan',
     pl: 'Zwykle nie zajmuje więcej niż',
-    hb: ''
+    hb: 'בדרך כלל לא יקח יותר מ...'
   },
   NOTIFICATION_REMINDER_NOW_DESC_2: {
     da: 'minutter',
@@ -917,7 +917,7 @@ export const Localisations = {
     it: 'minuti.',
     nl: 'minuten.',
     pl: 'minut',
-    hb: ''
+    hb: 'דקות'
   },
   NOTIFICATION_REMINDER_FORGOTTEN: {
     da: 'Du mangler at svare på spørgsmål',
@@ -927,7 +927,7 @@ export const Localisations = {
     it: 'Hai dimenticato un questionario?',
     nl: 'Heeft u een vragenlijst vergeten?',
     pl: 'Pominąłeś ankietę?',
-    hb: ''
+    hb: '?פספסת שאלון'
   },
   NOTIFICATION_REMINDER_FORGOTTEN_DESC: {
     da:
@@ -945,7 +945,7 @@ export const Localisations = {
     pl: 
       'Wygląda na to, że nie odpowiedziałeś na wszystkie pytania. Czy mógłbyś zrobić to teraz?',
     hb: 
-      ''  
+      '?נראה שלא ענית על כל השאלות. תוכל לעשות זאת כעת'  
   },
   NOTIFICATION_REMINDER_FORGOTTEN_ALERT_DEFAULT_DESC: {
     da:
@@ -963,7 +963,7 @@ export const Localisations = {
     pl: 
       'Pominąłeś to pytanie. Nie przejmuj się! Następna ankieta będzie dostępna wkrótce.',
     hb: 
-      ''  
+      '.פספסת את זאת. אל תדאג! מועד השאלון הבא יהיה בקרוב'  
   },
   NOTIFICATION_REMINDER_FORGOTTEN_ALERT_LASTOFNIGHT_DESC: {
     da:
@@ -981,7 +981,7 @@ export const Localisations = {
     pl: 
       'Pominąłeś ostatnie pytanie. Nie przejmuj się! Dobranoc.',
     hb: 
-      ''
+      'פספסת את האחרונה. אל תדאג! שיהיה לך לילה טוב'
   },
   MEASURE_PROGRESS: {
     da: 'Fremgang',
@@ -991,7 +991,7 @@ export const Localisations = {
     it: 'Progresso',
     nl: 'Voortgang',
     pl: 'Postęp',
-    hb: ''
+    hb: 'התקדמות'
   },
   MEASURE_STEPS: {
     da: 'Skridt',
@@ -1001,7 +1001,7 @@ export const Localisations = {
     it: 'Passi',
     nl: 'Stappen',
     pl: 'Kroki',
-    hb: ''
+    hb: 'צעדים'
   },
   MEASURE_HEART_RATE: {
     da: 'Hjerterytme',
@@ -1011,7 +1011,7 @@ export const Localisations = {
     it: 'Frequenza cardiaca',
     nl: 'Hartslagfrequentie',
     pl: 'Tętno',
-    hb: ''
+    hb: 'קצב לב'
   },
   CREDITS_TITLE: {
     da: 'Anerkendelser',
@@ -1021,7 +1021,7 @@ export const Localisations = {
     it: 'Crediti',
     nl: 'Credits',
     pl: 'Punkty',
-    hb: ''
+    hb: 'נקודות'
   },
   CREDITS_BODY: {
     da:
@@ -1039,7 +1039,7 @@ export const Localisations = {
     pl: 
       'przygotowane dla Ciebie przez RADAR-CNS. Aby uzyskać więcej informacji kliknij <a href="http://radar-base.org">aquí</a>.',
     hb: 
-      ''  
+      'נעשה באהבה בשבילך על ידי קונצרסיום RADAR-CNS.למידע נוסף לחץ- k <a href=http://radar-cns.org>here</a>.'  
   },
   TASK_CALENDAR_TITLE: {
     da: 'Dagens opgaver',
@@ -1049,7 +1049,7 @@ export const Localisations = {
     it: 'Le attività di oggi',
     nl: 'Taken voor vandaag',
     pl: 'Zadania na dziś',
-    hb: ''
+    hb: 'המשימות של היום'
   },
   TASK_INFO_WARN: {
     da: 'Kræver rolige omgivelser',
@@ -1059,7 +1059,7 @@ export const Localisations = {
     it: 'Richiede un posto tranquillo',
     nl: 'Vereist een rustige omgeving',
     pl: 'Wymaga cichego otoczenia',
-    hb: ''
+    hb: 'דורשת מקום שקט'
   },
   TASK_PROGRESS_TITLE: {
     da: 'I dag',
@@ -1069,7 +1069,7 @@ export const Localisations = {
     it: 'Oggi',
     nl: 'Vandaag',
     pl: 'Dziś',
-    hb: ''
+    hb: 'היום'
   },
   TASK_PROGRESS_COMPLETED: {
     da: 'Gennemført',
@@ -1079,7 +1079,7 @@ export const Localisations = {
     it: 'Completato',
     nl: 'Voltooid',
     pl: 'Ukończone',
-    hb: ''
+    hb: 'הושלם'
   },
   TASK_BAR_NEXT_TASK: {
     da: 'Din næste opgave starter om ',
@@ -1089,7 +1089,7 @@ export const Localisations = {
     it: 'La prossima attività inizierà tra ',
     nl: 'Uw volgende taak start over ',
     pl: 'Następne zadanie zacznie się za',
-    hb: ''
+    hb: 'המשימה הבאה שלך מתחילה בעוד'
   },
   TASK_BAR_NOW_TASK: {
     da: 'Din opgave starter ',
@@ -1099,7 +1099,7 @@ export const Localisations = {
     it: 'Il tuo compito inizia ',
     nl: 'Je taak begint ',
     pl: 'Twoje zadanie zacznie się',
-    hb: ''
+    hb: 'המשימה שלך מתחילה'
   },
   TASK_BAR_NEXT_TASK_SOON: {
     da: 'snart',
@@ -1109,7 +1109,7 @@ export const Localisations = {
     it: 'Presto',
     nl: 'binnenkort',
     pl: 'niedługo',
-    hb: ''
+    hb: 'בקרוב'
   },
   TASK_BAR_AFFIRMATION_1: {
     da: 'Godt klaret!',
@@ -1139,7 +1139,7 @@ export const Localisations = {
     it: 'Resisti! ',
     nl: 'Wacht! ',
     pl: 'Czekaj!',
-    hb: ''
+    hb: '!כל הכבוד'
   },
   TASK_BAR_TASK_LEFT_2: {
     da: 'Der er stadig et par spørgsmål tilbage',
@@ -1149,7 +1149,7 @@ export const Localisations = {
     it: 'Mancano ancora pochi questionari',
     nl: 'Er staan nog een paar vragenlijsten open',
     pl: 'Zostało jeszcze kilka ankiet.',
-    hb: ''
+    hb: '.נותרו עדיין מספר שאלונים'
   },
   TASK_BAR_NO_TASK_1: {
     da: 'Tag det roligt!',
@@ -1159,7 +1159,7 @@ export const Localisations = {
     it: 'Relax!',
     nl: 'Ontspan!',
     pl: 'Spokojnie!',
-    hb: ''
+    hb: '!תרגע'
   },
   TASK_BAR_NO_TASK_2: {
     da: 'Der er ingen opgaver I dag.',
@@ -1169,7 +1169,7 @@ export const Localisations = {
     it: 'Nessuna attività oggi.',
     nl: 'Geen taken vandaag.',
     pl: 'Na dziś nie ma żadnych zadań.',
-    hb: ''
+    hb: '.אין משימות היום'
   },
   TASK_TIME_HOUR_SINGLE: {
     da: 'time',
@@ -1179,7 +1179,7 @@ export const Localisations = {
     it: 'ora',
     nl: 'uur',
     pl: 'godz.',
-    hb: ''
+    hb: 'שעה'
   },
   TASK_TIME_HOUR_MULTIPLE: {
     da: 'timer',
@@ -1189,7 +1189,7 @@ export const Localisations = {
     it: 'ore',
     nl: 'uren',
     pl: 'godz.',
-    hb: ''
+    hb: 'שעות'
   },
   TASK_TIME_MINUTE_SINGLE: {
     da: 'minut',
@@ -1199,7 +1199,7 @@ export const Localisations = {
     it: 'minuto',
     nl: 'minuut',
     pl: 'min.',
-    hb: ''
+    hb: 'דקה'
   },
   TASK_TIME_MINUTE_MULTIPLE: {
     da: 'minutter',
@@ -1209,7 +1209,7 @@ export const Localisations = {
     it: 'minuti',
     nl: 'minuten',
     pl: 'min.',
-    hb: ''
+    hb: 'דקות'
   },
   TESTING_NOTIFICATIONS: {
     da: 'Testmeddelelser',
@@ -1219,7 +1219,7 @@ export const Localisations = {
     it: 'Test delle Notifiche',
     nl: 'Testen van Meldingen',
     pl: 'Powiadomienia testowe',
-    hb: ''
+    hb: 'בודק התראות'
   },
   TESTING_NOTIFICATIONS_MESSAGE: {
     da: 
@@ -1237,7 +1237,7 @@ export const Localisations = {
     pl: 
       'Zamknij aplikację i poczekaj 2 minuty na powiadomienie testowe',
     hb: 
-      ''
+      '.סגור את האפליקציה כעת וחכה 2 דקות להתראת מבחן'
   },
   CLOSE_APP: {
     da: 'Luk App',
@@ -1247,7 +1247,7 @@ export const Localisations = {
     it: 'Chiudi App',
     nl: 'App Sluiten',
     pl: 'Zamknij aplikację',
-    hb: ''
+    hb: 'סגור את האפליקציה'
   },
   WARNING_DO_NOT_CLOSE_APP: {
     da: 'Luk ikke appen',
@@ -1257,7 +1257,7 @@ export const Localisations = {
     it: "Non chiudere l'app",
     nl: 'Sluit de app niet',
     pl: 'Nie zamykaj aplikacji',
-    hb: ''
+    hb: 'אל תסגור את האפליקציה'
   },
   AUDIO_TASK_ALERT: {
     da: 'Lydopgave afbrudt',
@@ -1267,7 +1267,7 @@ export const Localisations = {
     it: 'Attività audio interrotta',
     nl: 'Audiotaak onderbroken',
     pl: 'Zadanie audio przerwane',
-    hb: ''
+    hb: 'משימת האודיו הופרעה'
   },
   AUDIO_TASK_ALERT_DESC: {
     da: 'Opgaven er afbrudt. Genstart opgaven.',
@@ -1277,7 +1277,7 @@ export const Localisations = {
     it: "L'attività è stata interrotta. Riavvia il compito.",
     nl: 'Taak is onderbroken. Start de taak opnieuw.',
     pl: 'Zadanie zostało przerwane. Zacznij od nowa.',
-    hb: ''
+    hb: 'המשימה הופסקה, התחל מחדש'
   },
   AUDIO_TASK_ATTEMPT_ALERT: {
     da: 'Forsøg tilbageværende',
@@ -1287,7 +1287,7 @@ export const Localisations = {
     it: 'Tentativi rimanenti',
     nl: 'Pogingen blijven',
     pl: 'Pozostało prób',
-    hb: ''
+    hb: 'נסיונות שנותר'
   },
   AUDIO_TASK_HAPPY_ALERT: {
     da: 'Indsend optagelse?',
@@ -1297,7 +1297,7 @@ export const Localisations = {
     it: 'Invia la registrazione?',
     nl: 'Opname verzenden?',
     pl: 'Dodaj nagranie',
-    hb: ''
+    hb: 'שלח הקלטה'
   },
   CONFIG_ERROR_DESC: {
     da: 'Config opdatering mislykkes. Prøve igen?',
@@ -1307,7 +1307,7 @@ export const Localisations = {
     it: "Errore nell'aggiornamento della configurazione. Riprovare?",
     nl: 'Config-update mislukt. Opnieuw?',
     pl: 'Nieudana konfiguracja akutualizacji. Powtórzyć?',
-    hb: ''
+    hb: '?עדכון קונפיג נכשל. לנסות שוב'
   },
   SPLASH_STATUS_UPDATING_CONFIG: {
     da: 'Opdaterer underretninger og planlæg...',
@@ -1317,7 +1317,7 @@ export const Localisations = {
     it: 'Aggiornamento notifiche e pianificazione...',
     nl: 'Meldingen en planning bijwerken...',
     pl: 'Zaktualizuj powiadomienia i harmonogram',
-    hb: ''
+    hb: '... מעדכן התראות ולוח זמנים'
   },
   SPLASH_STATUS_SENDING_LOGS: {
     da: 'Afsendelse af ubesvarede spørgeskemaer...',
@@ -1327,6 +1327,6 @@ export const Localisations = {
     it: 'Invio dei registri dei questionari persi ...',
     nl: 'Logboeken gemiste vragenlijst verzenden...',
     pl: 'Wyślij brakujące dzienniki kwestionariusza',
-    hb: ''
+    hb: '... שליחת יומני שאלון שהוחמצו'
   }
 }

--- a/src/assets/data/localisations.ts
+++ b/src/assets/data/localisations.ts
@@ -563,6 +563,26 @@ export const Localisations = {
     pl: 'Holenderski (niderlandzki)',
     hb: 'הולנדית'
   },
+  LANGUAGE_POLISH: {
+    da: 'polere',
+    de: 'Polieren',
+    en: 'Polish',
+    es: 'Polaco',
+    it: 'Polacco',
+    nl: 'Pools',
+    pl: 'Polski',
+    hb: 'פולני'
+  },
+  LANGUAGE_HEBREW: {
+    da: 'Hebrew',
+    de: 'Hebräisch',
+    en: 'Hebrew',
+    es: 'Hebreo',
+    it: 'Ebraico',
+    nl: 'Hebreeuws',
+    pl: 'hebrajski',
+    hb: 'עברית'
+  },
   BTN_ENROL_ENROL: {
     da: 'Registrering',
     de: 'Registrieren',

--- a/src/assets/data/localisations.ts
+++ b/src/assets/data/localisations.ts
@@ -1129,7 +1129,7 @@ export const Localisations = {
     it: 'Tutte le attività sono state completate.',
     nl: 'Alle taken voltooid.',
     pl: 'Wszystkie zadania ukończone.',
-    hb: ''
+    hb: '.כל המשימות הושלמו'
   },
   TASK_BAR_TASK_LEFT_1: {
     da: 'Vent venligst! ',

--- a/src/assets/data/localisations.ts
+++ b/src/assets/data/localisations.ts
@@ -27,8 +27,8 @@ export const Localisations = {
     es: 'a RADAR-Base',
     it: 'in RADAR-Base',
     nl: 'bij RADAR-Base',
-    pl: 'w RADAR-CNS',
-    hb: 'RADAR-CNS-ל'
+    pl: 'w RADAR-Base',
+    hb: 'RADAR-Base-ל'
   },
   ENROL_WELCOME_DESC: {
     da:
@@ -43,10 +43,9 @@ export const Localisations = {
       'Grazie per aver preso parte al nostro studio. Iniziamo il processo di arruolamento.',
     nl:
       'Bedankt voor uw deelname aan dit onderzoek. Laten we starten met het registratie-proces.',
-    pl: 
+    pl:
       'Dziękujemy za wzięcie udziału w badaniu. Przejdź przez proces rejestracji, byś mógł zacząć korzystać z aplikacji',
-    hb: 
-      '.תודה שאתם משתתף במחקר זה. בוא נתחיל את הליך ההרשמה באפליקציה'  
+    hb: '.תודה שאתם משתתף במחקר זה. בוא נתחיל את הליך ההרשמה באפליקציה'
   },
   ENROL_REGISTRATION: {
     da: 'Registrering',
@@ -71,10 +70,10 @@ export const Localisations = {
       'Prima di poter usare questa app, devi registrarti. Puoi scansionare il codice QR o inserire il token.',
     nl:
       'Voordat u de app kunt gebruiken, moeten we de app eerst registreren. U kunt de QR code scannen of het token invoeren.',
-    pl: 
+    pl:
       'Zanim będziesz mógł korzystać z aplikacji, musisz się zarejestrować. Możesz zeskanować kod QR lub wpisać Token',
-    hb: 
-      'לפני שתוכל להתחיל להשתמש באפליקציה, אנחנו צריכים שתרשם אליה. תוכל לעשות זאת באמצעות קוד QR או הזנת טוקן'  
+    hb:
+      'לפני שתוכל להתחיל להשתמש באפליקציה, אנחנו צריכים שתרשם אליה. תוכל לעשות זאת באמצעות קוד QR או הזנת טוקן'
   },
   ENROL_REGISTRATION_SCAN_DESC: {
     da:
@@ -89,10 +88,10 @@ export const Localisations = {
       'Premi il pulsante "Scan" e inquadra il codice QR che hai ricevuto dal personale dello studio. Qui sotto puoi vedere un QR di esempio.',
     nl:
       'Klik op de "Scan" knop en richt de camera op de QR code die u heeft ontvangen van de onderzoeker. Hieronder staat een voorbeeld van een QR code afgebeeld.',
-    pl: 
+    pl:
       'Kliknij przycisk Skanuj i skieruj aparat telefonu na kod QR, który otrzymałeś od badacza. Przykładowy kod QR znajduje się poniżej.',
-    hb: 
-      '.לחץ על כפתור הסריקה וכוון את הממלצה לקוד QR, שניתן לך מהחוקר. דוגמה לקוד QR מוצגת מטה'  
+    hb:
+      '.לחץ על כפתור הסריקה וכוון את הממלצה לקוד QR, שניתן לך מהחוקר. דוגמה לקוד QR מוצגת מטה'
   },
   ENROL_REGISTRATION_TOKEN_DESC: {
     da:
@@ -107,10 +106,10 @@ export const Localisations = {
       'Inserisci il token. Questo dovrebbe essere disponibile sotto il codice QR sul portale di gestione. Se non è presente, scansiona il codice QR.',
     nl:
       'Voer het token in. Dit moet beschikbaar zijn onder de QR-code op Management Portal. Indien niet aanwezig, scan de QR-code.',
-    pl: 
+    pl:
       'Wprowadź Token. Powinien być widoczny poniżej kodu QR w Mahagement Portal. Jeśli go tam nie znajdziesz, zeskanuj kod QR.',
-    hb: 
-      'הזן את הטוקן. זה אמור להיות זמין לך תחת הקוד QR בפורטל ניהול. אם הוא לא זמין, בבקשה סרוק את הקוד QR.'  
+    hb:
+      'הזן את הטוקן. זה אמור להיות זמין לך תחת הקוד QR בפורטל ניהול. אם הוא לא זמין, בבקשה סרוק את הקוד QR.'
   },
   ENROL_PREFERENCES: {
     da: 'Præferencer',
@@ -135,10 +134,10 @@ export const Localisations = {
       'Ti invieremo ogni settimana un riepilogo dei dati raccolti. Sentiti libero di selezionare solo gli argomenti di cui vuoi ricevere le informazioni.',
     nl:
       'We zullen u wekelijks samenvattingen sturen over uw verzamelde gegevens. U kunt zelf de onderwerpen selecteren waarover uw informatie wilt ontvangen.',
-    pl: 
+    pl:
       'Co tydzień wyślemy Ci podsumowanie zebranych przez nas danych. Wybierz wszystkie tematy, na temat których chciałbyś uzyskiwać informacje.',
-    hb: 
-      'נשלח לך סיכומים שבועיים על המידע שאתה שולח לנו. תרגיש חופשי לבחור כמה נושאים שתרצה לקבל עליהם מידע.'  
+    hb:
+      'נשלח לך סיכומים שבועיים על המידע שאתה שולח לנו. תרגיש חופשי לבחור כמה נושאים שתרצה לקבל עליהם מידע.'
   },
   ENROL_REGISTRATION_COMPLETE: {
     da: 'Registrering Afsluttet',
@@ -151,14 +150,21 @@ export const Localisations = {
     hb: 'הרשמה הושלמה'
   },
   ENROL_REGISTRATION_COMPLETE_DESC: {
-    da: "Du er nu med tilmelding til undersøgelsen. Klik på 'Afslut' for at begynde at generere din spørgeskemaplan og dine meddelelser.",
-    de: "Sie haben sich jetzt erfolgreich für die Studie angemeldet. Klicken Sie auf 'Fertig', um den Zeitplan und die Benachrichtigungen für Ihren Fragebogen zu erstellen.",
-    en: "You have now successfully enrolled in the study. Click 'Finish' to start generating your questionnaire schedule and notifications.",
-    es: "Ahora se ha inscrito con éxito en el estudio. Haga clic en 'Finalizar' para comenzar a generar su calendario de cuestionarios y notificaciones.",
-    it: "Ora ti sei iscritto con successo allo studio. Fai clic su 'Fine' per iniziare a generare la pianificazione del questionario e le notifiche.",
-    nl: "U bent nu succesvol ingeschreven voor het onderzoek. Klik op 'Voltooid' om uw vragenlijstschema en meldingen te genereren.",
-    pl: 'Z powodzeniem zarejestrowałeś się w badaniu. Kliknij „Zakończone”, aby wygenerować harmonogram kwestionariusza i powiadomienia',
-    hb: '.נרשמת בהצלחה למחקר. לחץ על 'סיום' כדי להתחיל ליצור את לוח הזמנים וההודעות שלך'
+    da:
+      "Du er nu med tilmelding til undersøgelsen. Klik på 'Afslut' for at begynde at generere din spørgeskemaplan og dine meddelelser.",
+    de:
+      "Sie haben sich jetzt erfolgreich für die Studie angemeldet. Klicken Sie auf 'Fertig', um den Zeitplan und die Benachrichtigungen für Ihren Fragebogen zu erstellen.",
+    en:
+      "You have now successfully enrolled in the study. Click 'Finish' to start generating your questionnaire schedule and notifications.",
+    es:
+      "Ahora se ha inscrito con éxito en el estudio. Haga clic en 'Finalizar' para comenzar a generar su calendario de cuestionarios y notificaciones.",
+    it:
+      "Ora ti sei iscritto con successo allo studio. Fai clic su 'Fine' per iniziare a generare la pianificazione del questionario e le notifiche.",
+    nl:
+      "U bent nu succesvol ingeschreven voor het onderzoek. Klik op 'Voltooid' om uw vragenlijstschema en meldingen te genereren.",
+    pl:
+      'Z powodzeniem zarejestrowałeś się w badaniu. Kliknij „Zakończone”, aby wygenerować harmonogram kwestionariusza i powiadomienia',
+    hb: `.נרשמת בהצלחה למחקר. לחץ על 'סיום' כדי להתחיל ליצור את לוח הזמנים וההודעות שלך`
   },
   FINISH_THANKS: {
     da: 'Tak fordi du udfyldte spørgeskemaet.',
@@ -212,10 +218,9 @@ export const Localisations = {
       'Sfortunatamente, puoi rispondere a questo questionario solo al momento della notifica.',
     nl:
       'Helaas kunt u deze vragenlijst alleen op het aangegeven tijdstip beantwoorden.',
-    pl: 
+    pl:
       'Niestety kwestionariusz można wypełniać tylko po otrzymaniu powiadomienia',
-    hb: 
-      '.לצערנו, אתה יכול לענות על השאלון רק כשיש ההתראה'  
+    hb: '.לצערנו, אתה יכול לענות על השאלון רק כשיש ההתראה'
   },
   CLINICAL_TASKS: {
     da: 'Kliniske vurderinger',
@@ -338,22 +343,17 @@ export const Localisations = {
     hb: 'מצב לילה'
   },
   SETTINGS_NOTIFICATIONS_NIGHTMOD_DESC: {
-    da: 
-      'Nattilstand stopper alle notifikationer imellem kl. 22:00 og 07:30.',
+    da: 'Nattilstand stopper alle notifikationer imellem kl. 22:00 og 07:30.',
     de:
       'Der Nachtmodus stoppt alle Benachrichtigungen zwischen 22:00 und 07:30.',
-    en: 
-      'Night Mode stops all notifications between 22:00 and 07:30.',
+    en: 'Night Mode stops all notifications between 22:00 and 07:30.',
     es:
       'La modalidad nocturna detiene todas las notificaciones entre las  22 y las  7:30 horas',
     it:
       "La modalità notte bloccherà tutte le notifiche dell'app tra le 22:00 e le 7:30.",
-    nl: 
-      'De nachtmodus blokkeert alle notificaties tussen 22:00u en 7:30u.',
-    pl: 
-      'Tryb nocny blokuje wszystkie powiadomienia między 22:00 a 07:30.',
-    hb: 
-      '.מצב לילה עוצר את כל ההתראות בין 22:00 ל- 7:30 למחרת'
+    nl: 'De nachtmodus blokkeert alle notificaties tussen 22:00u en 7:30u.',
+    pl: 'Tryb nocny blokuje wszystkie powiadomienia między 22:00 a 07:30.',
+    hb: '.מצב לילה עוצר את כל ההתראות בין 22:00 ל- 7:30 למחרת'
   },
   SETTINGS_REPORT: {
     da: 'Ugentlig rapport',
@@ -416,7 +416,7 @@ export const Localisations = {
     hb: '.אתה עומד לאפס את האפליקציה'
   },
   SETTINGS_RESET_ALERT_OPTION_DESC: {
-    da: 
+    da:
       'Vælg kun at nulstille appkonfiguration og data, eller udfør en fuldstændig nulstilling og tilmelding.',
     de:
       'Wählen Sie diese Option, um nur die App-Konfiguration und -Daten zurückzusetzen, oder führen Sie einen vollständigen Reset und eine erneute Registrierung durch.',
@@ -424,13 +424,13 @@ export const Localisations = {
       'Choose to reset app configuration and data only or do a full reset and re-enrol.',
     es:
       'Elija restablecer la configuración de la aplicación y solo los datos o realice un reinicio completo y vuelva a inscribirse.',
-    it: 
+    it:
       "Scegli di ripristinare solo la configurazione e i dati dell'app oppure eseguire un ripristino completo e ripetere la registrazione.",
-    nl: 
-      "Kies ervoor om de app-configuratie en -gegevens alleen opnieuw in te stellen of een volledige reset uit te voeren en opnieuw in te schrijven.",
+    nl:
+      'Kies ervoor om de app-configuratie en -gegevens alleen opnieuw in te stellen of een volledige reset uit te voeren en opnieuw in te schrijven.',
     pl:
       'wybierz tylko zresetować konfigurację i dane aplikacji lub wykonać pełny reset i ponownie zarejestrować',
-    hb: 
+    hb:
       '.בחר לאפס את תצורת ונתוני האפליקציה בלבד או לבצע איפוס מלא ולהירשם מחדש'
   },
   SETTINGS_CACHE: {
@@ -564,24 +564,24 @@ export const Localisations = {
     hb: 'הולנדית'
   },
   LANGUAGE_POLISH: {
-    da: 'polere',
-    de: 'Polieren',
+    da: 'Polish',
+    de: 'Polish',
     en: 'Polish',
-    es: 'Polaco',
-    it: 'Polacco',
-    nl: 'Pools',
-    pl: 'Polski',
-    hb: 'פולני'
+    es: 'Polish',
+    it: 'Polish',
+    nl: 'Polish',
+    pl: 'Polish',
+    hb: 'Polish'
   },
   LANGUAGE_HEBREW: {
     da: 'Hebrew',
-    de: 'Hebräisch',
+    de: 'Hebrew',
     en: 'Hebrew',
-    es: 'Hebreo',
-    it: 'Ebraico',
-    nl: 'Hebreeuws',
-    pl: 'hebrajski',
-    hb: 'עברית'
+    es: 'Hebrew',
+    it: 'Hebrew',
+    nl: 'Hebrew',
+    pl: 'Hebrew',
+    hb: 'Hebrew'
   },
   BTN_ENROL_ENROL: {
     da: 'Registrering',
@@ -654,7 +654,7 @@ export const Localisations = {
     hb: 'התחל'
   },
   BTN_STOP: {
-    da: 'Stoppe',
+    da: 'Stop',
     de: 'Stoppen',
     en: 'Stop',
     es: 'Detener',
@@ -788,13 +788,13 @@ export const Localisations = {
     de: 'Ja',
     en: 'Yes',
     es: 'Sí',
-    it: 'sì',
+    it: 'Sì',
     nl: 'Ja',
     pl: 'Tak',
     hb: 'כן'
   },
   BTN_NO: {
-    da: 'Ingen',
+    da: 'Nej',
     de: 'Nein',
     en: 'No',
     es: 'No',
@@ -805,13 +805,21 @@ export const Localisations = {
   },
   BTN_TRY_AGAIN: {
     da: 'Prøv igen',
-    de: 'Versuchen Sie es nochmal',
+    de: 'Erneut versuchen',
     en: 'Try again',
-    es: 'Inténtalo de nuevo',
-    it: 'Riprova',
-    nl: 'Probeer het opnieuw',
+    es: 'Volver a intentar',
+    it: 'Prova di nuovo',
+    nl: 'Probeer opnieuw',
     pl: 'Spróbuj ponownie',
     hb: 'נסה שוב'
+  },
+  BTN_UPDATE: {
+    da: 'Opdater',
+    de: 'Aktualisieren',
+    en: 'Update',
+    es: 'Actualizar',
+    it: 'Aggiorna',
+    nl: 'Bijwerken'
   },
   STATUS_LOADING: {
     da: 'Indlæser',
@@ -853,6 +861,22 @@ export const Localisations = {
     pl: 'NIe udało się',
     hb: 'נכשל'
   },
+  STATUS_UPDATE_AVAILABLE: {
+    da: 'Ny Version Tilgængelig',
+    de: 'Neue Version Verfügbar',
+    en: 'New Version Available',
+    es: 'Nueva Versión Disponible',
+    it: 'Nuova Versione Disponibile',
+    nl: 'Nieuwe Versie Beschikbaar'
+  },
+  STATUS_UPDATE_AVAILABLE_DESC: {
+    da: 'Opdater din app, før du fortsætter.',
+    de: 'Bitte aktualisieren Sie Ihre App, bevor Sie fortfahren.',
+    en: 'Please update your app before continuing.',
+    es: 'Actualice su aplicación antes de continuar.',
+    it: `Aggiorna l'app prima di continuare.`,
+    nl: 'Werk uw app bij voordat u doorgaat.'
+  },
   NOTIFICATION_TEST_REMINDER_NOW: {
     da: 'Testmeddelelse',
     de: 'Testbenachrichtigung',
@@ -880,34 +904,25 @@ export const Localisations = {
       'Der RADAR-CNS Fragebogen muss morgen ausgefüllt werden – bitte denken Sie daran.',
     en:
       'RADAR-CNS questionnaire needs to be completed tomorrow – please remember.',
-    es: 
-      'Recuerde que mañana tendrá que completar el cuestionario RADAR-CNS.',
-    it: 
-      'Ti ricordiamo che domani dovrai compilare il questionario RADAR-CNS.',
+    es: 'Recuerde que mañana tendrá que completar el cuestionario RADAR-CNS.',
+    it: 'Ti ricordiamo che domani dovrai compilare il questionario RADAR-CNS.',
     nl:
       'Vergeet u s.v.p. niet om de RADAR-CNS vragenlijst uiterlijk morgen in te vullen?',
-    pl: 
-      'Ankietę RADAR-CNS powinieneś wypełnić jutro – prosimy pamiętaj',
-    hb: 
-      'יש להשלים את שאלון RADAR-CNS מחר- נא לזכור'  
+    pl: 'Ankietę RADAR-CNS powinieneś wypełnić jutro – prosimy pamiętaj',
+    hb: 'יש להשלים את שאלון RADAR-CNS מחר- נא לזכור'
   },
   NOTIFICATION_REMINDER_SOON_DESC: {
-    da: 
-      'Husk at sætte lidt tid af i morgen, til at svare på et par spørgsmål.',
-    de: 
-      'Denken Sie daran, morgen etwas Zeit für ein paar Fragebögen zu haben.',
-    en: 
-      'Remember to put some time aside for a few questionnaires tomorrow.',
+    da: 'Husk at sætte lidt tid af i morgen, til at svare på et par spørgsmål.',
+    de: 'Denken Sie daran, morgen etwas Zeit für ein paar Fragebögen zu haben.',
+    en: 'Remember to put some time aside for a few questionnaires tomorrow.',
     es:
       'Recuerde reservarse el tiempo mañana para contestar algunos cuestionarios',
     it:
       'Domani ricordati di lasciare del tempo libero per rispondere a brevi questionari.',
     nl:
       'Vergeet u niet om morgen wat tijd vrij te maken voor het invullen van enkele vragenlijsten?',
-    pl: 
-      'Pamiętaj, by jutro zachować trochę czasu na wypełnienie ankiety.',
-    hb: 
-      'תזכור לפנות קצת זמן להשלים שאלונים מחר'  
+    pl: 'Pamiętaj, by jutro zachować trochę czasu na wypełnienie ankiety.',
+    hb: 'תזכור לפנות קצת זמן להשלים שאלונים מחר'
   },
   NOTIFICATION_REMINDER_NOW: {
     da: 'Tid til at svare på spørgsmål',
@@ -962,10 +977,9 @@ export const Localisations = {
       'Sembra che ti sia dimenticato di rispondere ad alcune domande. Puoi farlo ora?',
     nl:
       'Het lijkt erop dat u niet alle vragen heeft beantwoord. Zou u dit nu alsnog willen doen?',
-    pl: 
+    pl:
       'Wygląda na to, że nie odpowiedziałeś na wszystkie pytania. Czy mógłbyś zrobić to teraz?',
-    hb: 
-      '?נראה שלא ענית על כל השאלות. תוכל לעשות זאת כעת'  
+    hb: '?נראה שלא ענית על כל השאלות. תוכל לעשות זאת כעת'
   },
   NOTIFICATION_REMINDER_FORGOTTEN_ALERT_DEFAULT_DESC: {
     da:
@@ -980,28 +994,20 @@ export const Localisations = {
       'Hai perso questo. Non preoccuparti! Il prossimo quesionario sarà presto disponibile.',
     nl:
       'Je hebt deze gemist. Maak je geen zorgen! De volgende vragenlijst zal binnenkort verschijnen.',
-    pl: 
+    pl:
       'Pominąłeś to pytanie. Nie przejmuj się! Następna ankieta będzie dostępna wkrótce.',
-    hb: 
-      '.פספסת את זאת. אל תדאג! מועד השאלון הבא יהיה בקרוב'  
+    hb: '.פספסת את זאת. אל תדאג! מועד השאלון הבא יהיה בקרוב'
   },
   NOTIFICATION_REMINDER_FORGOTTEN_ALERT_LASTOFNIGHT_DESC: {
     da:
       'Du har ikke nået at svare på sidste spørgsmål. Ingen problemer! Hav en god aften.',
-    de: 
-      'Du hast den letzten verpasst. Mach dir keine Sorgen! Gute Nacht.',
-    en: 
-      "You've missed the last one. Dont worry! Have a good night.",
-    es: 
-      'No ha llegado a contestar el último. No se preocupe! Buenas noches!',
-    it: 
-      "Hai perso l'ultimo. Non preoccuparti! Buonanotte.",
-    nl: 
-      'Je hebt de laatste gemist. Maak je geen zorgen! Goede nacht.',
-    pl: 
-      'Pominąłeś ostatnie pytanie. Nie przejmuj się! Dobranoc.',
-    hb: 
-      'פספסת את האחרונה. אל תדאג! שיהיה לך לילה טוב'
+    de: 'Du hast den letzten verpasst. Mach dir keine Sorgen! Gute Nacht.',
+    en: "You've missed the last one. Dont worry! Have a good night.",
+    es: 'No ha llegado a contestar el último. No se preocupe! Buenas noches!',
+    it: "Hai perso l'ultimo. Non preoccuparti! Buonanotte.",
+    nl: 'Je hebt de laatste gemist. Maak je geen zorgen! Goede nacht.',
+    pl: 'Pominąłeś ostatnie pytanie. Nie przejmuj się! Dobranoc.',
+    hb: 'פספסת את האחרונה. אל תדאג! שיהיה לך לילה טוב'
   },
   MEASURE_PROGRESS: {
     da: 'Fremgang',
@@ -1052,14 +1058,14 @@ export const Localisations = {
       'Made with &hearts; for you by the RADAR-Base community. For more information click <a href="http://radar-base.org">here</a>.',
     es:
       'Hecho con &hearts;  para usted por la comunidad RADAR-Base. Para obtener más información, haga clic  en <a href="http://radar-base.org">aquí</a>.',
-    it: 
+    it:
       'Fatto con il &hearts; per te dalla comunità RADAR-Base. Per maggiori informazioni clicca <a href="http://radar-base.org">qui</a>.',
     nl:
       'Met &hearts; voor u gemaakt door de RADAR-Base community. Voor meer informatie klik <a href="http://radar-base.org">here</a>.',
-    pl: 
-      'przygotowane dla Ciebie przez RADAR-CNS. Aby uzyskać więcej informacji kliknij <a href="http://radar-base.org">aquí</a>.',
-    hb: 
-      'נעשה באהבה בשבילך על ידי קונצרסיום RADAR-CNS.למידע נוסף לחץ- k <a href=http://radar-cns.org>here</a>.'  
+    pl:
+      'przygotowane dla Ciebie przez RADAR-Base. Aby uzyskać więcej informacji kliknij <a href="http://radar-base.org">aquí</a>.',
+    hb:
+      'נעשה באהבה בשבילך על ידי קונצרסיום RADAR-Base.למידע נוסף לחץ- k <a href=http://radar-base.org>here</a>.'
   },
   TASK_CALENDAR_TITLE: {
     da: 'Dagens opgaver',
@@ -1108,8 +1114,8 @@ export const Localisations = {
     es: 'La siguiente tarea comienza en ',
     it: 'La prossima attività inizierà tra ',
     nl: 'Uw volgende taak start over ',
-    pl: 'Następne zadanie zacznie się za',
-    hb: 'המשימה הבאה שלך מתחילה בעוד'
+    pl: 'Następne zadanie zacznie się za ',
+    hb: 'המשימה הבאה שלך מתחילה בעוד '
   },
   TASK_BAR_NOW_TASK: {
     da: 'Din opgave starter ',
@@ -1118,8 +1124,8 @@ export const Localisations = {
     es: 'La tarea comienza ',
     it: 'Il tuo compito inizia ',
     nl: 'Je taak begint ',
-    pl: 'Twoje zadanie zacznie się',
-    hb: 'המשימה שלך מתחילה'
+    pl: 'Twoje zadanie zacznie się ',
+    hb: 'המשימה שלך מתחילה '
   },
   TASK_BAR_NEXT_TASK_SOON: {
     da: 'snart',
@@ -1158,8 +1164,8 @@ export const Localisations = {
     es: 'Espere! ',
     it: 'Resisti! ',
     nl: 'Wacht! ',
-    pl: 'Czekaj!',
-    hb: '!כל הכבוד'
+    pl: 'Czekaj! ',
+    hb: '!כל הכבוד '
   },
   TASK_BAR_TASK_LEFT_2: {
     da: 'Der er stadig et par spørgsmål tilbage',
@@ -1242,22 +1248,16 @@ export const Localisations = {
     hb: 'בודק התראות'
   },
   TESTING_NOTIFICATIONS_MESSAGE: {
-    da: 
-      'Luk nu appen og vent i 2 minutter for testmeddelelsen.',
+    da: 'Luk nu appen og vent i 2 minutter for testmeddelelsen.',
     de:
       'Schließen Sie nun die App und warten Sie 2 Minuten auf die Testbenachrichtigung.',
-    en: 
-      'Now close the app and wait for 2 minutes for the test notification.',
+    en: 'Now close the app and wait for 2 minutes for the test notification.',
     es:
       'Ahora cierre la aplicación y espere 2 minutos para la notificación de prueba.',
-    it: 
-      "Ora chiudi l'app e attendi 2 minuti per la notifica del test.",
-    nl: 
-      'Sluit nu de app en wacht 2 minuten op de testmelding.',
-    pl: 
-      'Zamknij aplikację i poczekaj 2 minuty na powiadomienie testowe',
-    hb: 
-      '.סגור את האפליקציה כעת וחכה 2 דקות להתראת מבחן'
+    it: "Ora chiudi l'app e attendi 2 minuti per la notifica del test.",
+    nl: 'Sluit nu de app en wacht 2 minuten op de testmelding.',
+    pl: 'Zamknij aplikację i poczekaj 2 minuty na powiadomienie testowe',
+    hb: '.סגור את האפליקציה כעת וחכה 2 דקות להתראת מבחן'
   },
   CLOSE_APP: {
     da: 'Luk App',
@@ -1300,7 +1300,7 @@ export const Localisations = {
     hb: 'המשימה הופסקה, התחל מחדש'
   },
   AUDIO_TASK_ATTEMPT_ALERT: {
-    da: 'Forsøg tilbageværende',
+    da: 'Tilbageværende forsøg',
     de: 'Verbleibende Versuche',
     en: 'Attempts remaining',
     es: 'Intentos restantes',

--- a/src/assets/data/localisations.ts
+++ b/src/assets/data/localisations.ts
@@ -147,7 +147,7 @@ export const Localisations = {
     es: 'Registro Completo',
     it: 'Registrazione Completa',
     nl: 'Registratie Compleet',
-    pl: '',
+    pl: 'Rejestracja zakończona',
     hb: ''
   },
   ENROL_REGISTRATION_COMPLETE_DESC: {
@@ -157,7 +157,7 @@ export const Localisations = {
     es: "Ahora se ha inscrito con éxito en el estudio. Haga clic en 'Finalizar' para comenzar a generar su calendario de cuestionarios y notificaciones.",
     it: "Ora ti sei iscritto con successo allo studio. Fai clic su 'Fine' per iniziare a generare la pianificazione del questionario e le notifiche.",
     nl: "U bent nu succesvol ingeschreven voor het onderzoek. Klik op 'Voltooid' om uw vragenlijstschema en meldingen te genereren.",
-    pl: '',
+    pl: 'Z powodzeniem zarejestrowałeś się w badaniu. Kliknij „Zakończone”, aby wygenerować harmonogram kwestionariusza i powiadomienia',
     hb: ''
   },
   FINISH_THANKS: {
@@ -187,7 +187,7 @@ export const Localisations = {
     es: 'Completado durante la visita clínica',
     it: 'Completato in clinica?',
     nl: 'Voltooid in de kliniek?',
-    pl: '',
+    pl: 'Ukończone w klinice',
     hb: ''
   },
   CALENDAR_ESM_MISSED_TITLE: {
@@ -412,7 +412,7 @@ export const Localisations = {
     es: 'Estás a punto de reiniciar la aplicación.',
     it: "Stai per ripristinare l'app.",
     nl: 'U staat op het punt de app opnieuw in te stellen.',
-    pl: '',
+    pl: 'Masz zamiar zresetować aplikację',
     hb: ''
   },
   SETTINGS_RESET_ALERT_OPTION_DESC: {
@@ -429,7 +429,7 @@ export const Localisations = {
     nl: 
       "Kies ervoor om de app-configuratie en -gegevens alleen opnieuw in te stellen of een volledige reset uit te voeren en opnieuw in te schrijven.",
     pl:
-      '',
+      'wybierz tylko zresetować konfigurację i dane aplikacji lub wykonać pełny reset i ponownie zarejestrować',
     hb: 
       ''
   },
@@ -480,7 +480,7 @@ export const Localisations = {
     es: 'Generar Notificación de Prueba',
     it: 'Genera Notifica di Prova',
     nl: 'Genereer Testmelding',
-    pl: '',
+    pl: 'wygeneruj powiadomienie o badaniu',
     hb: ''
   },
   SETTINGS_LOG_NOTIFS: {
@@ -490,7 +490,7 @@ export const Localisations = {
     es: 'Notificaciones de Registro',
     it: 'Registra le Notifiche',
     nl: 'Logmeldingen',
-    pl: '',
+    pl: 'Powiadomienia z dziennika',
     hb: ''
   },
   SETTINGS_SEND_CACHED_DATA: {
@@ -500,7 +500,7 @@ export const Localisations = {
     es: 'Enviar Datos en Caché',
     it: 'Invia Dati Memorizzati nella Cache',
     nl: 'Gegevens in Cache Verzenden',
-    pl: '',
+    pl: 'Wyślij dane z pamięci podręcznej',
     hb: ''
   },
   LANGUAGE_ENGLISH: {
@@ -560,7 +560,7 @@ export const Localisations = {
     es: 'Holandés',
     it: 'Olandese',
     nl: 'Nederlands',
-    pl: '',
+    pl: 'Holenderski (niderlandzki)',
     hb: ''
   },
   BTN_ENROL_ENROL: {
@@ -570,7 +570,7 @@ export const Localisations = {
     es: 'Registro',
     it: 'Registrazione',
     nl: 'Registreren',
-    pl: 'Holenderski (niderlandzki)',
+    pl: 'zarejestruj się',
     hb: ''
   },
   BTN_ENROL_SCAN: {
@@ -660,7 +660,7 @@ export const Localisations = {
     es: 'REintentar',
     it: 'Riprovare',
     nl: 'Probeer opnieuw',
-    pl: '',
+    pl: 'Spróbuj ponownie',
     hb: ''
   },
   BTN_AGREE: {
@@ -690,7 +690,7 @@ export const Localisations = {
     es: 'De acuerdo',
     it: 'Okay',
     nl: 'OK',
-    pl: '',
+    pl: 'OK',
     hb: ''
   },
   BTN_SET: {
@@ -840,7 +840,7 @@ export const Localisations = {
     es: 'Notificación de prueba',
     it: 'Notifica di prova',
     nl: 'Testmelding',
-    pl: '',
+    pl: 'powiadomienie o badaniu',
     hb: ''
   },
   NOTIFICATION_TEST_REMINDER_NOW_DESC: {
@@ -1316,7 +1316,7 @@ export const Localisations = {
     es: 'Actualizando notificaciones y programa...',
     it: 'Aggiornamento notifiche e pianificazione...',
     nl: 'Meldingen en planning bijwerken...',
-    pl: '',
+    pl: 'Zaktualizuj powiadomienia i harmonogram',
     hb: ''
   },
   SPLASH_STATUS_SENDING_LOGS: {
@@ -1326,7 +1326,7 @@ export const Localisations = {
     es: 'Enviando registros de cuestionarios perdidos...',
     it: 'Invio dei registri dei questionari persi ...',
     nl: 'Logboeken gemiste vragenlijst verzenden...',
-    pl: '',
+    pl: 'Wyślij brakujące dzienniki kwestionariusza',
     hb: ''
   }
 }

--- a/src/assets/data/localisations.ts
+++ b/src/assets/data/localisations.ts
@@ -78,21 +78,21 @@ export const Localisations = {
   },
   ENROL_REGISTRATION_SCAN_DESC: {
     da:
-      "Klik på 'Scan' knappen og hold kameraet over QR-koden som du får udleveret af forskeren. Du kan se et eksempel på en QR-kode herunder.",
+      'Klik på "Scan" knappen og hold kameraet over QR-koden som du får udleveret af forskeren. Du kan se et eksempel på en QR-kode herunder.',
     de:
-      "Klicken Sie auf die Schaltfläche 'Scannen' und richten Sie die Kamera auf den von Ihrem Forscher angegebenen QR-Code. Ein Beispiel für einen QR-Code finden Sie unten.",
+      'Klicken Sie auf die Schaltfläche "Scannen" und richten Sie die Kamera auf den von Ihrem Forscher angegebenen QR-Code. Ein Beispiel für einen QR-Code finden Sie unten.',
     en:
-      "Click the 'Scan' button and point the camera onto the QR code, given by your researcher. An example QR code is below.",
+      'Click the "Scan" button and point the camera onto the QR code, given by your researcher. An example QR code is below.',
     es:
-      "Presione el botón 'Escanear' e ingrese el código QR que le dio el personal del estudio. A continuación puede ver un ejemplo de código QR",
+      'Presione el botón "Escanear" e ingrese el código QR que le dio el personal del estudio. A continuación puede ver un ejemplo de código QR',
     it:
-      "Premi il pulsante 'Scan' e inquadra il codice QR che hai ricevuto dal personale dello studio. Qui sotto puoi vedere un QR di esempio.",
+      'Premi il pulsante "Scan" e inquadra il codice QR che hai ricevuto dal personale dello studio. Qui sotto puoi vedere un QR di esempio.',
     nl:
-      "Klik op de 'Scan' knop en richt de camera op de QR code die u heeft ontvangen van de onderzoeker. Hieronder staat een voorbeeld van een QR code afgebeeld.",
+      'Klik op de "Scan" knop en richt de camera op de QR code die u heeft ontvangen van de onderzoeker. Hieronder staat een voorbeeld van een QR code afgebeeld.',
     pl: 
-      "Kliknij przycisk Skanuj i skieruj aparat telefonu na kod QR, który otrzymałeś od badacza. Przykładowy kod QR znajduje się poniżej.",
+      'Kliknij przycisk Skanuj i skieruj aparat telefonu na kod QR, który otrzymałeś od badacza. Przykładowy kod QR znajduje się poniżej.',
     hb: 
-      ".לחץ על כפתור הסריקה וכוון את הממלצה לקוד QR, שניתן לך מהחוקר. דוגמה לקוד QR מוצגת מטה"  
+      '.לחץ על כפתור הסריקה וכוון את הממלצה לקוד QR, שניתן לך מהחוקר. דוגמה לקוד QR מוצגת מטה'  
   },
   ENROL_REGISTRATION_TOKEN_DESC: {
     da:

--- a/src/assets/data/localisations.ts
+++ b/src/assets/data/localisations.ts
@@ -564,24 +564,24 @@ export const Localisations = {
     hb: 'הולנדית'
   },
   LANGUAGE_POLISH: {
-    da: 'Polish',
-    de: 'Polish',
+    da: 'Polere',
+    de: 'Polieren',
     en: 'Polish',
-    es: 'Polish',
-    it: 'Polish',
-    nl: 'Polish',
-    pl: 'Polish',
-    hb: 'Polish'
+    es: 'Polaco',
+    it: 'Polacco',
+    nl: 'Pools',
+    pl: 'Polskie',
+    hb: 'פולני'
   },
   LANGUAGE_HEBREW: {
     da: 'Hebrew',
-    de: 'Hebrew',
+    de: 'Hebräisch',
     en: 'Hebrew',
-    es: 'Hebrew',
-    it: 'Hebrew',
-    nl: 'Hebrew',
-    pl: 'Hebrew',
-    hb: 'Hebrew'
+    es: 'Hebreo',
+    it: 'Ebraico',
+    nl: 'Hebreeuws',
+    pl: 'Hebrajski',
+    hb: 'עברית'
   },
   BTN_ENROL_ENROL: {
     da: 'Registrering',
@@ -654,7 +654,7 @@ export const Localisations = {
     hb: 'התחל'
   },
   BTN_STOP: {
-    da: 'Stop',
+    da: 'Stoppe',
     de: 'Stoppen',
     en: 'Stop',
     es: 'Detener',
@@ -819,7 +819,9 @@ export const Localisations = {
     en: 'Update',
     es: 'Actualizar',
     it: 'Aggiorna',
-    nl: 'Bijwerken'
+    nl: 'Bijwerken',
+    pl: 'zmodernizować',
+    hb: 'עדכון'
   },
   STATUS_LOADING: {
     da: 'Indlæser',
@@ -867,7 +869,9 @@ export const Localisations = {
     en: 'New Version Available',
     es: 'Nueva Versión Disponible',
     it: 'Nuova Versione Disponibile',
-    nl: 'Nieuwe Versie Beschikbaar'
+    nl: 'Nieuwe Versie Beschikbaar',
+    pl: 'Nowa wersja dostępna',
+    hb: 'גרסה חדשה זמינה'
   },
   STATUS_UPDATE_AVAILABLE_DESC: {
     da: 'Opdater din app, før du fortsætter.',
@@ -875,7 +879,9 @@ export const Localisations = {
     en: 'Please update your app before continuing.',
     es: 'Actualice su aplicación antes de continuar.',
     it: `Aggiorna l'app prima di continuare.`,
-    nl: 'Werk uw app bij voordat u doorgaat.'
+    nl: 'Werk uw app bij voordat u doorgaat.',
+    pl: 'Zaktualizuj aplikację przed kontynuowaniem',
+    hb: 'אנא עדכן את האפליקציה שלך לפני שתמשיך'
   },
   NOTIFICATION_TEST_REMINDER_NOW: {
     da: 'Testmeddelelse',
@@ -1145,7 +1151,7 @@ export const Localisations = {
     it: 'Ben fatto!',
     nl: 'Goed gedaan!',
     pl: 'Gratulacje!',
-    hb: ''
+    hb: 'הכבוד'
   },
   TASK_BAR_AFFIRMATION_2: {
     da: 'Alle opgaver er gennemført.',

--- a/src/assets/data/localisations.ts
+++ b/src/assets/data/localisations.ts
@@ -1025,21 +1025,21 @@ export const Localisations = {
   },
   CREDITS_BODY: {
     da:
-      "Lavet med &hearts; til dig af RADAR-Base-samfundet. For mere information click <a href='http://radar-base.org'>her</a>.",
+      'Lavet med &hearts; til dig af RADAR-Base-samfundet. For mere information click <a href="http://radar-base.org">her</a>.',
     de:
-      "Von der RADAR-Base-Community gemacht mit &hearts; für Sie gemacht. Für weitere Informationen klicken Sie <a href='http://radar-base.org'>hier</a>.",
+      'Von der RADAR-Base-Community gemacht mit &hearts; für Sie gemacht. Für weitere Informationen klicken Sie <a href="http://radar-base.org">hier</a>.',
     en:
-      "Made with &hearts; for you by the RADAR-Base community. For more information click <a href='http://radar-base.org'>here</a>.",
+      'Made with &hearts; for you by the RADAR-Base community. For more information click <a href="http://radar-base.org">here</a>.',
     es:
-      "Hecho con &hearts;  para usted por la comunidad RADAR-Base. Para obtener más información, haga clic  en <a href='http://radar-base.org'>aquí</a>.",
+      'Hecho con &hearts;  para usted por la comunidad RADAR-Base. Para obtener más información, haga clic  en <a href="http://radar-base.org">aquí</a>.',
     it: 
-      "Fatto con il &hearts; per te dalla comunità RADAR-Base. Per maggiori informazioni clicca <a href='http://radar-base.org'>qui</a>.",
+      'Fatto con il &hearts; per te dalla comunità RADAR-Base. Per maggiori informazioni clicca <a href="http://radar-base.org">qui</a>.',
     nl:
-      "Met &hearts; voor u gemaakt door de RADAR-Base community. Voor meer informatie klik <a href='http://radar-base.org'>here</a>.",
+      'Met &hearts; voor u gemaakt door de RADAR-Base community. Voor meer informatie klik <a href="http://radar-base.org">here</a>.',
     pl: 
-      "przygotowane dla Ciebie przez RADAR-CNS. Aby uzyskać więcej informacji kliknij <a href='http://radar-base.org'>aquí</a>.",
+      'przygotowane dla Ciebie przez RADAR-CNS. Aby uzyskać więcej informacji kliknij <a href="http://radar-base.org">aquí</a>.',
     hb: 
-      ""  
+      ''  
   },
   TASK_CALENDAR_TITLE: {
     da: 'Dagens opgaver',


### PR DESCRIPTION
Added Hebrew and Polish translations. (some changes to these translations might have to occur after an initial test run with native speakers - I will take care of this)
Made some small changes:
1. ''> "" > ` ` where possible
2. visual: items with long text were sometimes put on a new line for some languages and not for others, I changed this (although it makes no difference, it looks nicer to have it the same for every language)
3. for one item there was Italian text under danish - changed it to danish (auto-translate)