### PR TITLE
Add support for custom showIntroduction values

### DIFF
--- a/src/app/pages/questions/containers/questions-page.component.ts
+++ b/src/app/pages/questions/containers/questions-page.component.ts
@@ -6,7 +6,10 @@ import { LocalizationService } from '../../../core/services/misc/localization.se
 import { UsageService } from '../../../core/services/usage/usage.service'
 import { UsageEventType } from '../../../shared/enums/events'
 import { LocKeys } from '../../../shared/enums/localisations'
-import { Assessment } from '../../../shared/models/assessment'
+import {
+  Assessment,
+  ShowIntroductionType
+} from '../../../shared/models/assessment'
 import { Question } from '../../../shared/models/question'
 import { Task } from '../../../shared/models/task'
 import { TaskType } from '../../../shared/utilities/task-type'
@@ -39,6 +42,11 @@ export class QuestionsPageComponent implements OnInit {
   showIntroductionScreen: boolean
   showDoneButton: boolean
   showFinishScreen: boolean
+  SHOW_INTRODUCTION_SET: Set<boolean | ShowIntroductionType> = new Set([
+    true,
+    ShowIntroductionType.ALWAYS,
+    ShowIntroductionType.ONCE
+  ])
 
   constructor(
     public navCtrl: NavController,
@@ -62,7 +70,9 @@ export class QuestionsPageComponent implements OnInit {
     return data.then(res => {
       this.questionTitle = res.title
       this.introduction = res.introduction
-      this.showIntroductionScreen = res.assessment.showIntroduction
+      this.showIntroductionScreen = this.SHOW_INTRODUCTION_SET.has(
+        res.assessment.showIntroduction
+      )
       this.questions = res.questions
       this.endText =
         res.endText && res.endText.length

--- a/src/app/pages/questions/services/questions.service.ts
+++ b/src/app/pages/questions/services/questions.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core'
 
 import { QuestionnaireService } from '../../../core/services/config/questionnaire.service'
 import { LocalizationService } from '../../../core/services/misc/localization.service'
+import { ShowIntroductionType } from '../../../shared/models/assessment'
 import { Question, QuestionType } from '../../../shared/models/question'
 import { getTaskType } from '../../../shared/utilities/task-type'
 import { getSeconds } from '../../../shared/utilities/time'
@@ -66,7 +67,7 @@ export class QuestionsService {
   }
 
   updateAssessmentIntroduction(assessment, taskType) {
-    if (assessment.showIntroduction) {
+    if (assessment.showIntroduction !== ShowIntroductionType.ALWAYS) {
       assessment.showIntroduction = false
       this.questionnaire.updateAssessment(taskType, assessment)
     }

--- a/src/app/shared/models/assessment.ts
+++ b/src/app/shared/models/assessment.ts
@@ -10,7 +10,7 @@ export interface Assessment {
   startText?: MultiLanguageText
   endText?: MultiLanguageText
   warn?: MultiLanguageText
-  showIntroduction?: boolean
+  showIntroduction?: boolean | ShowIntroductionType
   isDemo?: boolean
   questions: Question[]
   showInCalendar?: boolean
@@ -23,4 +23,10 @@ export interface QuestionnaireMetadata {
   avsc: string
   type?: string
   format?: string
+}
+
+export enum ShowIntroductionType {
+  ALWAYS = 'always',
+  ONCE = 'once',
+  NEVER = 'never'
 }


### PR DESCRIPTION
- Adds support for `showIntroduction` property in the protocol:
  - `always` will show the introduction screen every time the assessment is started, 
  - `once` will show the introduction screen the first time that type of assessment is started, 
  - `never` will not show the introduction screen
(NOTE: in addition to `true`, which is the same as `once`, and `false`)

Solves #790 