### PR TITLE
Use remote config to get latest app version update

### DIFF
--- a/src/app/core/services/config/config.service.spec.ts
+++ b/src/app/core/services/config/config.service.spec.ts
@@ -13,7 +13,8 @@ import {
   ProtocolServiceMock,
   QuestionnaireServiceMock,
   ScheduleServiceMock,
-  SubjectConfigServiceMock
+  SubjectConfigServiceMock,
+  RemoteConfigServiceMock
 } from '../../../shared/testing/mock-services'
 import { KafkaService } from '../kafka/kafka.service'
 import { LocalizationService } from '../misc/localization.service'
@@ -26,6 +27,7 @@ import { ConfigService } from './config.service'
 import { ProtocolService } from './protocol.service'
 import { QuestionnaireService } from './questionnaire.service'
 import { SubjectConfigService } from './subject-config.service'
+import { RemoteConfigService } from './remote-config.service';
 
 describe('ConfigService', () => {
   let service
@@ -49,7 +51,8 @@ describe('ConfigService', () => {
         { provide: LogService, useClass: LogServiceMock },
         HttpClient,
         HttpHandler,
-        { provide: Platform, useClass: PlatformMock }
+        { provide: Platform, useClass: PlatformMock },
+        { provide: RemoteConfigService, useClass: RemoteConfigServiceMock },
       ]
     })
   )

--- a/src/app/pages/splash/containers/splash-page.component.ts
+++ b/src/app/pages/splash/containers/splash-page.component.ts
@@ -39,6 +39,9 @@ export class SplashPageComponent {
     this.status = this.localization.translateKey(
       LocKeys.SPLASH_STATUS_UPDATING_CONFIG
     )
+    this.splash
+      .isAppUpdateAvailable()
+      .then(res => (res ? this.showAppUpdateAvailable() : []))
     return this.splash
       .loadConfig()
       .then(() => {
@@ -47,11 +50,7 @@ export class SplashPageComponent {
         )
         return this.splash.sendMissedQuestionnaireLogs()
       })
-      .catch(e =>
-        e.message == ConfigEventType.APP_UPDATE_AVAILABLE
-          ? this.showAppUpdateAvailable()
-          : this.showFetchConfigFail(e)
-      )
+      .catch(e => this.showFetchConfigFail(e))
       .then(() => this.navCtrl.setRoot(HomePageComponent))
   }
 

--- a/src/app/pages/splash/containers/splash-page.component.ts
+++ b/src/app/pages/splash/containers/splash-page.component.ts
@@ -22,13 +22,13 @@ export class SplashPageComponent {
   constructor(
     public navCtrl: NavController,
     public navParams: NavParams,
-    private splash: SplashService,
+    private splashService: SplashService,
     private alertService: AlertService,
     private localization: LocalizationService,
     private usage: UsageService,
     private platform: Platform
   ) {
-    this.splash
+    this.splashService
       .evalEnrolment()
       .then(valid => (valid ? this.onStart() : this.enrol()))
   }
@@ -39,16 +39,16 @@ export class SplashPageComponent {
     this.status = this.localization.translateKey(
       LocKeys.SPLASH_STATUS_UPDATING_CONFIG
     )
-    this.splash
+    this.splashService
       .isAppUpdateAvailable()
       .then(res => (res ? this.showAppUpdateAvailable() : []))
-    return this.splash
+    return this.splashService
       .loadConfig()
       .then(() => {
         this.status = this.localization.translateKey(
           LocKeys.SPLASH_STATUS_SENDING_LOGS
         )
-        return this.splash.sendMissedQuestionnaireLogs()
+        return this.splashService.sendMissedQuestionnaireLogs()
       })
       .catch(e => this.showFetchConfigFail(e))
       .then(() => this.navCtrl.setRoot(HomePageComponent))
@@ -100,6 +100,8 @@ export class SplashPageComponent {
   }
 
   enrol() {
-    this.splash.reset().then(() => this.navCtrl.setRoot(EnrolmentPageComponent))
+    this.splashService
+      .reset()
+      .then(() => this.navCtrl.setRoot(EnrolmentPageComponent))
   }
 }

--- a/src/app/pages/splash/services/splash.service.ts
+++ b/src/app/pages/splash/services/splash.service.ts
@@ -24,6 +24,10 @@ export class SplashService {
     return this.config.fetchConfigState()
   }
 
+  isAppUpdateAvailable() {
+    return this.config.checkForAppUpdates()
+  }
+
   reset() {
     return this.config.resetAll()
   }

--- a/src/app/shared/enums/config.ts
+++ b/src/app/shared/enums/config.ts
@@ -9,6 +9,7 @@ export class ConfigKeys {
   static NOTIFICATION_TTL_MINUTES = new ConfigKeys('notification_ttl_minutes')
   static PLATFORM_INSTANCE = new ConfigKeys('platform_instance')
   static QUESTIONS_HIDDEN = new ConfigKeys('questions_hidden')
+  static APP_VERSION_LATEST = new ConfigKeys('app_version_latest')
 
   constructor(public value: string) {}
 


### PR DESCRIPTION
- Use remote config (temporary fix) to get the latest app version update instead of scraping play store due to CORS issues