### PR TITLE
WIP: Add support for dayOfWeek in questionnaire protocols

### DIFF
--- a/src/app/core/services/schedule/schedule-generator.service.ts
+++ b/src/app/core/services/schedule/schedule-generator.service.ts
@@ -122,7 +122,10 @@ export class ScheduleGeneratorService {
       assessment.protocol,
       type
     )
-    let iterTime = refTimestamp
+    const dayOfWeek = repeatP.dayOfWeek
+    let iterTime = dayOfWeek
+      ? this.shiftDayOfWeek(refTimestamp, dayOfWeek)
+      : refTimestamp
     const endTime =
       iterTime + getMilliseconds({ years: DefaultScheduleYearCoverage })
     const completionWindow = ScheduleGeneratorService.computeCompletionWindow(
@@ -216,6 +219,23 @@ export class ScheduleGeneratorService {
       })
     }
     return { schedule, completed }
+  }
+
+  shiftDayOfWeek(refTimestamp, dayOfWeek) {
+    const moment = this.localization.moment(refTimestamp)
+    const now = moment.day()
+    if (now <= dayOfWeek) {
+      return moment
+        .day(dayOfWeek)
+        .toDate()
+        .getTime()
+    } else {
+      return moment
+        .add(1, 'weeks')
+        .day(dayOfWeek)
+        .toDate()
+        .getTime()
+    }
   }
 
   static computeCompletionWindow(assessment: Assessment): number {

--- a/src/app/core/services/schedule/schedule-generator.service.ts
+++ b/src/app/core/services/schedule/schedule-generator.service.ts
@@ -223,19 +223,17 @@ export class ScheduleGeneratorService {
 
   shiftDayOfWeek(refTimestamp, dayOfWeek) {
     const moment = this.localization.moment(refTimestamp)
-    const now = moment.day()
-    if (now <= dayOfWeek) {
-      return moment
-        .day(dayOfWeek)
-        .toDate()
-        .getTime()
-    } else {
-      return moment
-        .add(1, 'weeks')
-        .day(dayOfWeek)
-        .toDate()
-        .getTime()
-    }
+    const target = moment.day(dayOfWeek).valueOf()
+    return moment.valueOf() <= target
+      ? moment
+          .day(dayOfWeek)
+          .toDate()
+          .getTime()
+      : moment
+          .add(1, 'w')
+          .day(dayOfWeek)
+          .toDate()
+          .getTime()
   }
 
   static computeCompletionWindow(assessment: Assessment): number {

--- a/src/app/core/services/schedule/schedule-generator.service.ts
+++ b/src/app/core/services/schedule/schedule-generator.service.ts
@@ -117,12 +117,12 @@ export class ScheduleGeneratorService {
     const dayOfWeek = repeatP.dayOfWeek
     // NOTE: If ref timestamp is specified in the protocol
     const refTime = protocol.referenceTimestamp
-      ? new Date(protocol.referenceTimestamp).getTime()
+      ? setDateTimeToMidnight(new Date(protocol.referenceTimestamp)).getTime()
       : refTimestamp
     // NOTE: If day of the week is specified in the protocol
     const iterTime = dayOfWeek
       ? this.shiftDayOfWeek(refTime, dayOfWeek)
-      : refTimestamp
+      : refTime
     return iterTime
   }
 

--- a/src/app/shared/models/protocol.ts
+++ b/src/app/shared/models/protocol.ts
@@ -12,11 +12,13 @@ export interface Protocol {
   reminders?: Reminder[] | Reminders
   clinicalProtocol?: ClinicalProtocol
   completionWindow?: TimeInterval
+  referenceTimestamp?: string
 }
 
 export interface TimeInterval {
   unit?: string
   amount?: number
+  dayOfWeek?: string
 }
 
 export interface RepeatQuestionnaire {


### PR DESCRIPTION
- Adds support for a new key in the protocol: `dayOfWeek` to specify the day of the week the protocol should keep repeating on. This will shift the original reference timestamp day to the specified day.
- Adds support for `referenceTimestamp`. If present, this will override the default referenceTimestamp which is the midnight of the user's enrollment date. The reference timestamp is the initial date to start schedule generation from. If `dayOfWeek` is present, this will shift the day of the reference timestamp as well.

To add: repeatProtocol validation?

<pre>
"protocol": {
        <b>"referenceTimestamp": "2020-01-01T14:48:00.000Z",</b>
        "repeatProtocol": {
          <b>"dayOfWeek": "Mon",</b>
          "unit": "day",
          "amount": 14
        },
        "repeatQuestionnaire": {
          "unit": "min",
          "unitsFromZero": [570]
        },
        "reminders": {
          "unit": "day",
          "amount": 0,
          "repeat": 0
        },
        "completionWindow": {
          "unit": "day",
          "amount": 3
        }
      }
</pre>