### PR TITLE
Allow schedule year coverage to be changed from remote config

### DIFF
--- a/src/app/core/services/schedule/schedule-generator.service.spec.ts
+++ b/src/app/core/services/schedule/schedule-generator.service.spec.ts
@@ -5,10 +5,12 @@ import {
   LogServiceMock,
   NotificationGeneratorServiceMock,
   QuestionnaireServiceMock,
+  RemoteConfigServiceMock,
   UtilityMock
 } from '../../../shared/testing/mock-services'
 import { Utility } from '../../../shared/utilities/util'
 import { QuestionnaireService } from '../config/questionnaire.service'
+import { RemoteConfigService } from '../config/remote-config.service'
 import { LocalizationService } from '../misc/localization.service'
 import { LogService } from '../misc/log.service'
 import { NotificationGeneratorService } from '../notifications/notification-generator.service'
@@ -34,7 +36,8 @@ describe('ScheduleGeneratorService', () => {
         {
           provide: Utility,
           useClass: UtilityMock
-        }
+        },
+        { provide: RemoteConfigService, useClass: RemoteConfigServiceMock }
       ]
     })
   )

--- a/src/app/core/services/schedule/schedule-generator.service.ts
+++ b/src/app/core/services/schedule/schedule-generator.service.ts
@@ -135,7 +135,6 @@ export class ScheduleGeneratorService {
     type: AssessmentType
   ): Task[] {
     const scheduleYearCoverage = this.getScheduleYearCoverage()
-    console.log(scheduleYearCoverage)
     const { repeatP, repeatQ } = this.getRepeatProtocol(
       assessment.protocol,
       type

--- a/src/app/shared/enums/config.ts
+++ b/src/app/shared/enums/config.ts
@@ -17,6 +17,7 @@ export class ConfigKeys {
   static PARTICIPANT_ATTRIBUTE_ORDER = new ConfigKeys(
     'participant_attribute_order'
   )
+  static SCHEDULE_YEAR_COVERAGE = new ConfigKeys('schedule_year_coverage')
 
   constructor(public value: string) {}
 

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -72,7 +72,7 @@ export const DefaultTask: Task = {
 }
 
 // *Default schedule coverage in years (length of schedule to generate tasks until)
-export const DefaultScheduleYearCoverage: number = 2
+export const DefaultScheduleYearCoverage: number = 3
 
 // *Default time interval of protocol
 export const DefaultScheduleTimeInterval = { unit: 'day', amount: 1 }


### PR DESCRIPTION
- Change `DefaultScheduleYearCoverage` to 3 years from 2 years
- Add support for changing this value in the remote config