### PR TITLE
Minor app server/rest notification fixes

### DIFF
--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -305,9 +305,8 @@ export class ConfigService {
         .then(() => this.analytics.setUserProperties(user))
         .then(() => this.appConfig.init(user.enrolmentDate)),
       this.localization.init(),
-      this.kafka.init(),
-      this.notifications.init()
-    ])
+      this.kafka.init()
+    ]).then(() => this.notifications.init())
   }
 
   getAll() {

--- a/src/app/core/services/notifications/fcm-notification.service.spec.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing'
 import { FirebaseX } from '@ionic-native/firebase-x/ngx'
 import { Platform } from 'ionic-angular'
-import { PlatformMock } from 'ionic-mocks'
 
 import {
   FirebaseMock,
@@ -29,7 +28,7 @@ describe('FcmNotificationService', () => {
     TestBed.configureTestingModule({
       providers: [
         FcmNotificationService,
-        { provide: Platform, useClass: PlatformMock },
+        Platform,
         { provide: FirebaseX, useClass: FirebaseMock },
         { provide: LogService, useClass: LogServiceMock },
         { provide: StorageService, useClass: StorageServiceMock },
@@ -47,6 +46,8 @@ describe('FcmNotificationService', () => {
 
   beforeEach(() => {
     service = TestBed.get(FcmNotificationService)
+    const platform = TestBed.get(Platform)
+    spyOn(platform, 'ready').and.callFake(() => Promise.resolve(''))
   })
 
   it('should create', () => {

--- a/src/app/core/services/notifications/fcm-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.ts
@@ -34,16 +34,18 @@ export abstract class FcmNotificationService extends NotificationService {
     public remoteConfig: RemoteConfigService
   ) {
     super(store)
-    this.remoteConfig.subject().subscribe(cfg => {
-      cfg
-        .getOrDefault(
-          ConfigKeys.NOTIFICATION_TTL_MINUTES,
-          String(this.ttlMinutes)
-        )
-        .then(
-          ttl =>
-            (this.ttlMinutes = Number(ttl) || DefaultNotificationTtlMinutes)
-        )
+    this.platform.ready().then(() => {
+      this.remoteConfig.subject().subscribe(cfg => {
+        cfg
+          .getOrDefault(
+            ConfigKeys.NOTIFICATION_TTL_MINUTES,
+            String(this.ttlMinutes)
+          )
+          .then(
+            ttl =>
+              (this.ttlMinutes = Number(ttl) || DefaultNotificationTtlMinutes)
+          )
+      })
     })
   }
 

--- a/src/app/core/services/notifications/fcm-rest-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-rest-notification.service.ts
@@ -224,6 +224,7 @@ export class FcmRestNotificationService extends FcmNotificationService {
           return res.body
         })
         .catch((err: HttpErrorResponse) => {
+          this.logger.log('Http request returned an error: ' + err.message)
           const data: FcmNotificationError = err.error
           if (err.status == 409) {
             this.logger.log(

--- a/src/app/core/services/notifications/fcm-rest-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-rest-notification.service.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../assets/data/defaultConfig'
 import {
   FcmNotificationDto,
+  FcmNotificationError,
   FcmNotifications
 } from '../../../shared/models/app-server'
 import { AssessmentType } from '../../../shared/models/assessment'
@@ -223,12 +224,19 @@ export class FcmRestNotificationService extends FcmNotificationService {
           return res.body
         })
         .catch((err: HttpErrorResponse) => {
-          if (err.status == 409) return err.message['dto']
+          const data: FcmNotificationError = err.error
+          if (err.status == 409) {
+            this.logger.log(
+              'Notification already exists, storing notification data..'
+            )
+            return data.dto ? data.dto : notification.notification
+          }
           return this.logger.error('Failed to send notification', err)
         })
         .then((resultNotification: FcmNotificationDto) => {
           notification.notification.id = resultNotification.id
-          notification.notification.messageId = resultNotification.fcmMessageId
+          return (notification.notification.messageId =
+            resultNotification.fcmMessageId)
         })
     )
   }

--- a/src/app/core/services/token/token.service.spec.ts
+++ b/src/app/core/services/token/token.service.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClient, HttpHandler } from '@angular/common/http'
 import { TestBed } from '@angular/core/testing'
 import { JwtHelperService } from '@auth0/angular-jwt'
+import { Platform } from 'ionic-angular'
 
 import {
   JwtHelperServiceMock,
@@ -22,6 +23,7 @@ describe('TokenService', () => {
         TokenService,
         HttpClient,
         HttpHandler,
+        Platform,
         { provide: RemoteConfigService, useClass: RemoteConfigServiceMock },
         { provide: JwtHelperService, useClass: JwtHelperServiceMock },
         { provide: StorageService, useClass: StorageServiceMock },
@@ -32,6 +34,8 @@ describe('TokenService', () => {
 
   beforeEach(() => {
     service = TestBed.get(TokenService)
+    const platform = TestBed.get(Platform)
+    spyOn(platform, 'ready').and.callFake(() => Promise.resolve(''))
   })
 
   it('should create', () => {

--- a/src/app/pages/auth/services/auth.service.ts
+++ b/src/app/pages/auth/services/auth.service.ts
@@ -12,7 +12,7 @@ import { SubjectConfigService } from '../../../core/services/config/subject-conf
 import { LogService } from '../../../core/services/misc/log.service'
 import { TokenService } from '../../../core/services/token/token.service'
 import { AnalyticsService } from '../../../core/services/usage/analytics.service'
-import { MetaToken } from '../../../shared/models/token'
+import { MetaToken, OAuthToken } from '../../../shared/models/token'
 import { isValidURL } from '../../../shared/utilities/form-validators'
 
 @Injectable()
@@ -64,7 +64,7 @@ export class AuthService {
     })
   }
 
-  registerToken(registrationToken): Promise<void> {
+  registerToken(registrationToken): Promise<OAuthToken> {
     return this.token.register(this.token.getRefreshParams(registrationToken))
   }
 

--- a/src/app/pages/splash/services/splash.service.ts
+++ b/src/app/pages/splash/services/splash.service.ts
@@ -20,8 +20,7 @@ export class SplashService {
   }
 
   loadConfig() {
-    this.token.refresh()
-    return this.config.fetchConfigState()
+    return this.token.refresh().then(() => this.config.fetchConfigState())
   }
 
   isAppUpdateAvailable() {

--- a/src/app/shared/models/app-server.ts
+++ b/src/app/shared/models/app-server.ts
@@ -9,6 +9,7 @@ export interface FcmNotificationDto {
   title: string
   ttlSeconds: number
   type: string
+  fcmMessageId?: number
 }
 
 export interface FcmNotifications {

--- a/src/app/shared/models/app-server.ts
+++ b/src/app/shared/models/app-server.ts
@@ -12,6 +12,12 @@ export interface FcmNotificationDto {
   fcmMessageId?: number
 }
 
+export interface FcmNotificationError {
+  dto?: FcmNotificationDto
+  errorMessage: string
+  message: string
+}
+
 export interface FcmNotifications {
   notifications?: Array<FcmNotificationDto>
 }


### PR DESCRIPTION
- Refresh tokens instead of simply getting tokens before making app server requests
- Force fetch pulling app server url from remote config
- Wrap service initialisation inside `platform.ready()` to ensure Firebase is ready
- Handle 409 conflict when sending notifications that are already present in the server