### PR TITLE
Add subject attributes as separate user properties in Firebase

### DIFF
--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -304,6 +304,7 @@ export class ConfigService {
       this.subjectConfig
         .init(user)
         .then(() => this.analytics.setUserProperties(user))
+        .then(() => this.analytics.setUserProperties(user.attributes))
         .then(() => this.appConfig.init(user.enrolmentDate)),
       this.localization.init(),
       this.kafka.init(),

--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -29,6 +29,8 @@ import { SubjectConfigService } from './subject-config.service'
 
 @Injectable()
 export class ConfigService {
+  ATTRIBUTE_KEY_PREFIX = 'att-'
+
   constructor(
     private schedule: ScheduleService,
     private notifications: NotificationService,
@@ -304,7 +306,12 @@ export class ConfigService {
       this.subjectConfig
         .init(user)
         .then(() => this.analytics.setUserProperties(user))
-        .then(() => this.analytics.setUserProperties(user.attributes))
+        .then(() =>
+          this.analytics.setUserProperties(
+            user.attributes,
+            this.ATTRIBUTE_KEY_PREFIX
+          )
+        )
         .then(() => this.appConfig.init(user.enrolmentDate)),
       this.localization.init(),
       this.kafka.init(),

--- a/src/app/core/services/config/protocol.service.spec.ts
+++ b/src/app/core/services/config/protocol.service.spec.ts
@@ -2,11 +2,13 @@ import { HttpClient, HttpHandler } from '@angular/common/http'
 import { TestBed } from '@angular/core/testing'
 
 import {
+  FirebaseAnalyticsServiceMock,
   LogServiceMock,
   RemoteConfigServiceMock,
   SubjectConfigServiceMock
 } from '../../../shared/testing/mock-services'
 import { LogService } from '../misc/log.service'
+import { AnalyticsService } from '../usage/analytics.service'
 import { ProtocolService } from './protocol.service'
 import { RemoteConfigService } from './remote-config.service'
 import { SubjectConfigService } from './subject-config.service'
@@ -22,7 +24,11 @@ describe('ProtocolService', () => {
         HttpHandler,
         { provide: SubjectConfigService, useClass: SubjectConfigServiceMock },
         { provide: RemoteConfigService, useClass: RemoteConfigServiceMock },
-        { provide: LogService, useClass: LogServiceMock }
+        { provide: LogService, useClass: LogServiceMock },
+        {
+          provide: AnalyticsService,
+          useClass: FirebaseAnalyticsServiceMock
+        }
       ]
     })
   )

--- a/src/app/core/services/config/protocol.service.ts
+++ b/src/app/core/services/config/protocol.service.ts
@@ -21,6 +21,7 @@ import {
 import { ProtocolMetaData } from '../../../shared/models/protocol'
 import { sortObject } from '../../../shared/utilities/sort-object'
 import { LogService } from '../misc/log.service'
+import { AnalyticsService } from '../usage/analytics.service'
 import { RemoteConfigService } from './remote-config.service'
 import { SubjectConfigService } from './subject-config.service'
 
@@ -34,7 +35,8 @@ export class ProtocolService {
     private config: SubjectConfigService,
     private http: HttpClient,
     private remoteConfig: RemoteConfigService,
-    private logger: LogService
+    private logger: LogService,
+    private analytics: AnalyticsService
   ) {}
 
   pull(): Promise<ProtocolMetaData> {
@@ -179,21 +181,21 @@ export class ProtocolService {
       .then(cfg =>
         Promise.all([
           this.config.getParticipantAttributes(),
+          this.config.pullSubjectInformation(),
           this.getParticipantAttributeOrder(cfg)
         ])
       )
-      .then(([attributes, order]) => {
-        return new Promise(resolve => {
-          if (attributes == null)
-            this.config.pullSubjectInformation().then(user => {
-              this.config.setParticipantAttributes(user.attributes)
-              resolve((attributes = user.attributes))
-            })
-          else resolve()
-        }).then(() => {
-          const orderWithoutNull = this.formatAttributeOrder(attributes, order)
-          return sortObject(attributes, orderWithoutNull)
-        })
+      .then(([attributes, user, order]) => {
+        const newAttributes =
+          JSON.stringify(attributes) == JSON.stringify(user.attributes)
+            ? attributes
+            : user.attributes
+        this.config.setParticipantAttributes(newAttributes)
+        this.analytics.setUserProperties(newAttributes)
+        return sortObject(
+          newAttributes,
+          this.formatAttributeOrder(newAttributes, order)
+        )
       })
   }
 

--- a/src/app/core/services/usage/analytics.service.ts
+++ b/src/app/core/services/usage/analytics.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core'
+
 import { User } from '../../../shared/models/user'
 
 @Injectable()
@@ -6,7 +7,7 @@ export class AnalyticsService {
   logEvent(event: string, params?: any): Promise<void> {
     return undefined
   }
-  setUserProperties(properties: User): Promise<void> {
+  setUserProperties(properties: User, keyPrefix?: string): Promise<void> {
     return undefined
   }
   setUserId(id: string): Promise<void> {

--- a/src/app/core/services/usage/firebase-analytics.service.ts
+++ b/src/app/core/services/usage/firebase-analytics.service.ts
@@ -78,7 +78,10 @@ export class FirebaseAnalyticsService extends AnalyticsService {
    * ```
    */
 
-  setUserProperties(userProperties: User | Object): Promise<any> {
+  setUserProperties(
+    userProperties: User | Object,
+    keyPrefix?: string
+  ): Promise<any> {
     if (!this.platform.is('cordova'))
       return Promise.resolve('Could not load firebase')
 
@@ -88,7 +91,7 @@ export class FirebaseAnalyticsService extends AnalyticsService {
         .map(([key, value]) => {
           return this.firebase.setUserProperty(
             this.crop(
-              key,
+              keyPrefix ? keyPrefix + key : key,
               24,
               `Firebase User Property name ${key} is too long, cropping`
             ),

--- a/src/app/core/services/usage/firebase-analytics.service.ts
+++ b/src/app/core/services/usage/firebase-analytics.service.ts
@@ -78,7 +78,7 @@ export class FirebaseAnalyticsService extends AnalyticsService {
    * ```
    */
 
-  setUserProperties(userProperties: User): Promise<any> {
+  setUserProperties(userProperties: User | Object): Promise<any> {
     if (!this.platform.is('cordova'))
       return Promise.resolve('Could not load firebase')
 

--- a/src/app/pages/settings/containers/settings-page.component.html
+++ b/src/app/pages/settings/containers/settings-page.component.html
@@ -61,20 +61,6 @@
 
   <ion-item-group>
     <ion-item-divider no-lines>{{
-      'SETTINGS_REPORT' | translate
-    }}</ion-item-divider>
-    <ion-item no-lines *ngFor="let subSetting of weeklyReport; let i = index">
-      <ion-label>{{ subSetting.name | translate }}</ion-label>
-      <ion-toggle
-        item-right
-        [(ngModel)]="subSetting.show"
-        (ionChange)="weeklyReportChange(i)"
-      ></ion-toggle>
-    </ion-item>
-  </ion-item-group>
-
-  <ion-item-group>
-    <ion-item-divider no-lines>{{
       'SETTINGS_CACHE' | translate
     }}</ion-item-divider>
     <ion-item no-lines>


### PR DESCRIPTION
- Firebase user property values have a 36 character count limit which is not enough for a subject's MP attributes, so this adds subject attributes as separate Firebase user properties
- This also checks for changes in the MP attributes during every protocol refresh since previously we only import it once