### PR TITLE
Matrix input and other improvements

### DIFF
--- a/src/app/pages/questions/components/question/matrix-radio-input/matrix-radio-input.component.ts
+++ b/src/app/pages/questions/components/question/matrix-radio-input/matrix-radio-input.component.ts
@@ -16,6 +16,8 @@ export class MatrixRadioInputComponent implements OnInit {
   responses: Response[]
   @Input()
   currentlyShown: boolean
+  @Input()
+  previouslyShown: boolean
 
   value: number = null
   uniqueID: number = uniqueID++
@@ -33,7 +35,7 @@ export class MatrixRadioInputComponent implements OnInit {
   }
 
   ngOnChanges() {
-    if (this.currentlyShown)
+    if (this.currentlyShown && !this.previouslyShown)
       setTimeout(() => this.onInputChange(this.responses[0].code), 100)
   }
 

--- a/src/app/pages/questions/components/question/matrix-radio-input/matrix-radio-input.component.ts
+++ b/src/app/pages/questions/components/question/matrix-radio-input/matrix-radio-input.component.ts
@@ -14,6 +14,8 @@ export class MatrixRadioInputComponent implements OnInit {
 
   @Input()
   responses: Response[]
+  @Input()
+  currentlyShown: boolean
 
   value: number = null
   uniqueID: number = uniqueID++
@@ -28,9 +30,10 @@ export class MatrixRadioInputComponent implements OnInit {
         value: item.code
       })
     })
-    setTimeout(() => {
-      this.onInputChange(this.responses[0].code)
-    }, 500)
+  }
+
+  ngOnChanges() {
+    this.onInputChange(this.responses[0].code)
   }
 
   onInputChange(event) {

--- a/src/app/pages/questions/components/question/matrix-radio-input/matrix-radio-input.component.ts
+++ b/src/app/pages/questions/components/question/matrix-radio-input/matrix-radio-input.component.ts
@@ -33,7 +33,8 @@ export class MatrixRadioInputComponent implements OnInit {
   }
 
   ngOnChanges() {
-    this.onInputChange(this.responses[0].code)
+    if (this.currentlyShown)
+      setTimeout(() => this.onInputChange(this.responses[0].code), 100)
   }
 
   onInputChange(event) {

--- a/src/app/pages/questions/components/question/question.component.html
+++ b/src/app/pages/questions/components/question/question.component.html
@@ -130,6 +130,7 @@
         <matrix-radio-input
           *ngSwitchCase="'matrix-radio'"
           [responses]="question.select_choices_or_calculations"
+          [currentlyShown]="currentlyShown"
           (valueChange)="onValueChange($event)"
         >
         </matrix-radio-input>

--- a/src/app/pages/questions/components/question/question.component.html
+++ b/src/app/pages/questions/components/question/question.component.html
@@ -5,7 +5,7 @@
   [class.content-matrix]="isMatrix"
 >
   <div class="header" dir="auto">
-    <p>{{ question.section_header }}</p>
+    <p *ngIf="!isSectionHeaderHidden">{{ question.section_header }}</p>
     <div
       *ngIf="!isFieldLabelHidden"
       class="field-container"

--- a/src/app/pages/questions/components/question/question.component.html
+++ b/src/app/pages/questions/components/question/question.component.html
@@ -131,6 +131,7 @@
           *ngSwitchCase="'matrix-radio'"
           [responses]="question.select_choices_or_calculations"
           [currentlyShown]="currentlyShown"
+          [previouslyShown]="previouslyShown"
           (valueChange)="onValueChange($event)"
         >
         </matrix-radio-input>

--- a/src/app/pages/questions/components/question/question.component.ts
+++ b/src/app/pages/questions/components/question/question.component.ts
@@ -5,7 +5,7 @@ import {
   OnChanges,
   OnInit,
   Output,
-  ViewChild,
+  ViewChild
 } from '@angular/core'
 import { Dialogs } from '@ionic-native/dialogs/ngx'
 import { Vibration } from '@ionic-native/vibration/ngx'
@@ -29,6 +29,8 @@ export class QuestionComponent implements OnInit, OnChanges {
   questionIndex: number
   @Input()
   currentIndex: number
+  @Input()
+  isSectionHeaderHidden: boolean
   @Output()
   answer: EventEmitter<Answer> = new EventEmitter<Answer>()
 

--- a/src/app/pages/questions/containers/questions-page.component.html
+++ b/src/app/pages/questions/containers/questions-page.component.html
@@ -26,6 +26,7 @@
                 [question]="question"
                 [questionIndex]="i"
                 [currentIndex]="currentQuestionGroupId"
+                [isSectionHeaderHidden]="j != currentQuestionIndices[0]"
                 (answer)="onAnswer($event)"
               ></question>
             </ng-container>

--- a/src/app/pages/questions/containers/questions-page.component.html
+++ b/src/app/pages/questions/containers/questions-page.component.html
@@ -16,14 +16,16 @@
               let i = index
             "
           >
-            <ng-container *ngFor="let question of item.value">
+            <ng-container *ngFor="let question of item.value; let j = index">
               <question
                 *ngIf="
-                  i >= currentQuestionId - 10 && i <= currentQuestionId + 10
+                  i >= currentQuestionGroupId - 10 &&
+                  i <= currentQuestionGroupId + 10 &&
+                  currentQuestionIndices.includes(j)
                 "
                 [question]="question"
                 [questionIndex]="i"
-                [currentIndex]="currentQuestionId"
+                [currentIndex]="currentQuestionGroupId"
                 (answer)="onAnswer($event)"
               ></question>
             </ng-container>
@@ -54,7 +56,7 @@
     (finish)="navigateToFinishPage()"
     [isLeftButtonDisabled]="isLeftButtonDisabled"
     [isRightButtonDisabled]="isRightButtonDisabled"
-    [currentQuestionId]="currentQuestionId"
+    [currentQuestionId]="currentQuestionGroupId"
     [totalQuestions]="groupedQuestions?.size"
   ></toolbar>
 </ion-footer>

--- a/src/app/pages/questions/containers/questions-page.component.ts
+++ b/src/app/pages/questions/containers/questions-page.component.ts
@@ -25,8 +25,8 @@ export class QuestionsPageComponent implements OnInit {
   slides: Slides
 
   startTime: number
-  currentQuestionId = 0
-  nextQuestionId: number
+  currentQuestionGroupId = 0
+  nextQuestionGroupId: number
   questionOrder = [0]
   isLeftButtonDisabled = false
   isRightButtonDisabled = true
@@ -35,6 +35,8 @@ export class QuestionsPageComponent implements OnInit {
   questions: Question[]
   // Questions grouped by matrix group if it exists
   groupedQuestions: Map<string, Question[]>
+  // Indices of questions (of the group) currently shown
+  currentQuestionIndices: number[]
   questionTitle: string
   endText: string
   isLastTask: boolean
@@ -106,6 +108,10 @@ export class QuestionsPageComponent implements OnInit {
     this.assessment = res.assessment
     this.taskType = res.type
     this.requiresInClinicCompletion = this.assessment.requiresInClinicCompletion
+    const groupKeys = Array.from(this.groupedQuestions.keys())
+    this.currentQuestionIndices = Object.keys(
+      this.groupedQuestions.get(groupKeys[0])
+    ).map(Number)
   }
 
   groupQuestionsByMatrixGroup(questions: Question[]) {
@@ -146,7 +152,7 @@ export class QuestionsPageComponent implements OnInit {
   onAnswer(event) {
     if (event.id) {
       this.questionsService.submitAnswer(event)
-      this.updateToolbarButtons()
+      setTimeout(() => this.updateToolbarButtons(), 100)
     }
     if (this.questionsService.getIsNextAutomatic(event.type)) {
       this.nextQuestion()
@@ -155,7 +161,7 @@ export class QuestionsPageComponent implements OnInit {
 
   slideQuestion() {
     this.slides.lockSwipes(false)
-    this.slides.slideTo(this.currentQuestionId, 300)
+    this.slides.slideTo(this.currentQuestionGroupId, 300)
     this.slides.lockSwipes(true)
 
     this.startTime = this.questionsService.getTime()
@@ -163,7 +169,9 @@ export class QuestionsPageComponent implements OnInit {
 
   getCurrentQuestions() {
     // NOTE: For non-matrix type this will only return one question (array) but for matrix types this can be more than one
-    const key = Array.from(this.groupedQuestions.keys())[this.currentQuestionId]
+    const key = Array.from(this.groupedQuestions.keys())[
+      this.currentQuestionGroupId
+    ]
     return this.groupedQuestions.get(key)
   }
 
@@ -175,21 +183,25 @@ export class QuestionsPageComponent implements OnInit {
   }
 
   nextQuestion() {
-    this.nextQuestionId = this.questionsService.getNextQuestion(
+    const questionPosition = this.questionsService.getNextQuestion(
       this.groupedQuestions,
-      this.currentQuestionId
+      this.currentQuestionGroupId
     )
+    this.nextQuestionGroupId = questionPosition.groupKeyIndex
+    this.currentQuestionIndices = questionPosition.questionIndices
     if (this.isLastQuestion()) return this.navigateToFinishPage()
-    this.questionOrder.push(this.nextQuestionId)
+    this.questionOrder.push(this.nextQuestionGroupId)
     this.submitTimestamps()
-    this.currentQuestionId = this.nextQuestionId
+    this.currentQuestionGroupId = this.nextQuestionGroupId
     this.slideQuestion()
     this.updateToolbarButtons()
   }
 
   previousQuestion() {
     this.questionOrder.pop()
-    this.currentQuestionId = this.questionOrder[this.questionOrder.length - 1]
+    this.currentQuestionGroupId = this.questionOrder[
+      this.questionOrder.length - 1
+    ]
     this.updateToolbarButtons()
     if (!this.isRightButtonDisabled) this.questionsService.deleteLastAnswer()
     this.slideQuestion()
@@ -245,7 +257,7 @@ export class QuestionsPageComponent implements OnInit {
   }
 
   isLastQuestion() {
-    return this.nextQuestionId >= this.groupedQuestions.size
+    return this.nextQuestionGroupId >= this.groupedQuestions.size
   }
 
   asIsOrder(a, b) {

--- a/src/app/pages/questions/containers/questions-page.component.ts
+++ b/src/app/pages/questions/containers/questions-page.component.ts
@@ -197,7 +197,9 @@ export class QuestionsPageComponent implements OnInit {
 
   updateToolbarButtons() {
     // NOTE: Only the first question of each question group is used
-    const currentQuestionsFirstQ = this.getCurrentQuestions()[0]
+    const currentQs = this.getCurrentQuestions()
+    if (!currentQs) return
+    const currentQuestionsFirstQ = currentQs[0]
     this.isRightButtonDisabled =
       !this.questionsService.isAnswered(currentQuestionsFirstQ) &&
       !this.questionsService.getIsNextEnabled(currentQuestionsFirstQ.field_type)
@@ -217,7 +219,7 @@ export class QuestionsPageComponent implements OnInit {
     this.showFinishScreen = true
     this.onQuestionnaireCompleted()
     this.slides.lockSwipes(false)
-    this.slides.slideTo(this.questions.length, 500)
+    this.slides.slideTo(this.groupedQuestions.size, 500)
     this.slides.lockSwipes(true)
   }
 
@@ -243,7 +245,7 @@ export class QuestionsPageComponent implements OnInit {
   }
 
   isLastQuestion() {
-    return this.nextQuestionId >= this.questions.length
+    return this.nextQuestionId >= this.groupedQuestions.size
   }
 
   asIsOrder(a, b) {

--- a/src/app/pages/questions/containers/questions-page.component.ts
+++ b/src/app/pages/questions/containers/questions-page.component.ts
@@ -198,12 +198,14 @@ export class QuestionsPageComponent implements OnInit {
   }
 
   previousQuestion() {
+    const currentQuestions = this.getCurrentQuestions()
     this.questionOrder.pop()
     this.currentQuestionGroupId = this.questionOrder[
       this.questionOrder.length - 1
     ]
     this.updateToolbarButtons()
-    if (!this.isRightButtonDisabled) this.questionsService.deleteLastAnswer()
+    if (!this.isRightButtonDisabled)
+      this.questionsService.deleteLastAnswers(currentQuestions)
     this.slideQuestion()
   }
 
@@ -211,12 +213,11 @@ export class QuestionsPageComponent implements OnInit {
     // NOTE: Only the first question of each question group is used
     const currentQs = this.getCurrentQuestions()
     if (!currentQs) return
-    const currentQuestionsFirstQ = currentQs[0]
     this.isRightButtonDisabled =
-      !this.questionsService.isAnswered(currentQuestionsFirstQ) &&
-      !this.questionsService.getIsNextEnabled(currentQuestionsFirstQ.field_type)
-    this.isLeftButtonDisabled = this.questionsService.getIsPreviousDisabled(
-      currentQuestionsFirstQ.field_type
+      !this.questionsService.isAnyAnswered(currentQs) &&
+      !this.questionsService.getIsAnyNextEnabled(currentQs)
+    this.isLeftButtonDisabled = this.questionsService.getIsAnyPreviousEnabled(
+      currentQs
     )
   }
 

--- a/src/app/pages/questions/services/finish-task.service.ts
+++ b/src/app/pages/questions/services/finish-task.service.ts
@@ -59,12 +59,14 @@ export class FinishTaskService {
 
   processQuestionnaireData(answers, timestamps, questions) {
     this.logger.log('Answers to process', answers)
-    const values = Object.entries(answers).map(([key, value]) => ({
-      questionId: { string: key.toString() },
-      value: { string: value.toString() },
-      startTime: timestamps[key].startTime,
-      endTime: timestamps[key].endTime
-    }))
+    const values = Object.entries(answers)
+      .filter(([k, v]) => timestamps[k])
+      .map(([key, value]) => ({
+        questionId: { string: key.toString() },
+        value: { string: value.toString() },
+        startTime: timestamps[key].startTime,
+        endTime: timestamps[key].endTime
+      }))
     return {
       answers: values,
       scheduleVersion: '',
@@ -87,7 +89,7 @@ export class FinishTaskService {
 
   cancelNotificationsForCompletedTask(task): Promise<any> {
     console.log('Cancelling pending reminders for task..')
-    const notifications = task.notifications
+    const notifications = task.notifications ? task.notifications : []
     return notifications.forEach(n => this.config.cancelSingleNotification(n))
   }
 }

--- a/src/app/pages/questions/services/questions.service.ts
+++ b/src/app/pages/questions/services/questions.service.ts
@@ -49,6 +49,13 @@ export class QuestionsService {
     this.answerService.pop()
   }
 
+  deleteLastAnswers(questions: Question[]) {
+    const questionKeys = questions.map(q => q.field_name)
+    this.answerService.keys = this.answerService.keys.filter(
+      k => !questionKeys.includes(k)
+    )
+  }
+
   submitAnswer(answer) {
     this.answerService.add(answer)
   }
@@ -93,6 +100,10 @@ export class QuestionsService {
   isAnswered(question: Question) {
     const id = question.field_name
     return this.answerService.check(id)
+  }
+
+  isAnyAnswered(questions: Question[]) {
+    return questions.some(q => this.isAnswered(q))
   }
 
   getNextQuestion(groupedQuestions, currentQuestionId): QuestionPosition {
@@ -154,8 +165,18 @@ export class QuestionsService {
     return this.PREVIOUS_BUTTON_DISABLED_SET.has(questionType)
   }
 
+  getIsAnyPreviousEnabled(questions: Question[]) {
+    // NOTE: This checks if any question in the array has previous button enabled
+    return questions.some(q => this.getIsPreviousDisabled(q.field_type))
+  }
+
   getIsNextEnabled(questionType: string) {
     return this.NEXT_BUTTON_ENABLED_SET.has(questionType)
+  }
+
+  getIsAnyNextEnabled(questions: Question[]) {
+    // NOTE: This checks if any question in the array has next button enabled
+    return questions.some(q => this.getIsNextEnabled(q.field_type))
   }
 
   getIsNextAutomatic(questionType: string) {

--- a/src/app/pages/questions/services/questions.service.ts
+++ b/src/app/pages/questions/services/questions.service.ts
@@ -98,13 +98,13 @@ export class QuestionsService {
     while (
       qIndex < groupKeys.length &&
       this.isNotNullOrEmpty(
-        groupedQuestions.get(groupKeys[qIndex]).branching_logic
+        groupedQuestions.get(groupKeys[qIndex])[0].branching_logic
       )
     ) {
       const answers = this.util.deepCopy(this.answerService.answers)
       if (
         parseAndEvalLogic(
-          groupedQuestions.get(groupKeys[qIndex]).branching_logic,
+          groupedQuestions.get(groupKeys[qIndex])[0].branching_logic,
           answers
         )
       )

--- a/src/app/shared/models/question.ts
+++ b/src/app/shared/models/question.ts
@@ -69,3 +69,8 @@ export interface InfoItem {
   heading: string
   content: string
 }
+
+export interface QuestionPosition {
+  groupKeyIndex: number
+  questionIndices: number[]
+}


### PR DESCRIPTION
- Check if matrix input is currently shown before submitting default answers
- Fix sliding to finish page (because this was still using the `questions` array instead of `groupedQuestions` map)
- Fix branching logic in matrix group (we are getting the question array from the map key so the first question's index should be added)
- Fix `processQuestionnaireData` (add check for null timestamps)