### PR TITLE
Unregister from Firebase on app reset

### DIFF
--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -281,6 +281,7 @@ export class ConfigService {
   resetAll() {
     this.sendConfigChangeEvent(ConfigEventType.APP_RESET)
     this.cancelNotifications()
+    this.notifications.unregisterFromNotificataions()
     return Promise.all([this.resetConfig(), this.resetCache()]).then(() =>
       this.subjectConfig.reset()
     )

--- a/src/app/core/services/notifications/fcm-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.ts
@@ -50,6 +50,7 @@ export abstract class FcmNotificationService extends NotificationService {
   }
 
   init() {
+    this.firebase.setAutoInitEnabled(true)
     if (!this.platform.is('ios'))
       FirebasePlugin.setDeliveryMetricsExportToBigQuery(true)
     FirebasePlugin.setSenderId(
@@ -110,6 +111,13 @@ export abstract class FcmNotificationService extends NotificationService {
     return timeUntilEnd > 0
       ? getSeconds({ milliseconds: timeUntilEnd })
       : getSeconds({ minutes: this.ttlMinutes })
+  }
+
+  unregisterFromNotificataions(): Promise<any> {
+    // NOTE: This will delete the current device token and stop receiving notifications
+    return this.firebase
+      .setAutoInitEnabled(false)
+      .then(() => this.firebase.unregister())
   }
 
   abstract getSubjectDetails()

--- a/src/app/core/services/notifications/fcm-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.ts
@@ -61,11 +61,10 @@ export abstract class FcmNotificationService extends NotificationService {
         alert(error)
       }
     )
-    this.firebase.getToken().then(token => {
-      this.FCM_TOKEN = token
-      this.setFCMToken(token)
-      this.logger.log('[NOTIFICATION SERVICE] Refresh token success')
-    })
+    this.firebase
+      .onTokenRefresh()
+      .subscribe(token => this.onTokenRefresh(token))
+    this.firebase.getToken().then(token => this.onTokenRefresh(token))
   }
 
   publish(
@@ -118,6 +117,14 @@ export abstract class FcmNotificationService extends NotificationService {
     return this.firebase
       .setAutoInitEnabled(false)
       .then(() => this.firebase.unregister())
+  }
+
+  onTokenRefresh(token) {
+    if (token) {
+      this.FCM_TOKEN = token
+      this.setFCMToken(token)
+      this.logger.log('[NOTIFICATION SERVICE] Refresh token success')
+    }
   }
 
   abstract getSubjectDetails()

--- a/src/app/core/services/notifications/local-notification.service.ts
+++ b/src/app/core/services/notifications/local-notification.service.ts
@@ -4,7 +4,10 @@ import { LocalNotifications } from '@ionic-native/local-notifications/ngx'
 import { DefaultNumberOfNotificationsToSchedule } from '../../../../assets/data/defaultConfig'
 import { StorageKeys } from '../../../shared/enums/storage'
 import { AssessmentType } from '../../../shared/models/assessment'
-import { NotificationActionType, SingleNotification } from '../../../shared/models/notification-handler'
+import {
+  NotificationActionType,
+  SingleNotification
+} from '../../../shared/models/notification-handler'
 import { LogService } from '../misc/log.service'
 import { ScheduleService } from '../schedule/schedule.service'
 import { StorageService } from '../storage/storage.service'
@@ -98,5 +101,9 @@ export class LocalNotificationService extends NotificationService {
     return this.sendNotification(
       this.format(this.notifications.createTestNotification())
     )
+  }
+
+  unregisterFromNotificataions(): Promise<any> {
+    return Promise.resolve('Method not available for notification type.')
   }
 }

--- a/src/app/core/services/notifications/notification-factory.service.ts
+++ b/src/app/core/services/notifications/notification-factory.service.ts
@@ -62,6 +62,10 @@ export class NotificationFactoryService extends NotificationService {
     return this.notificationService.publish(type, limit, notificationId)
   }
 
+  unregisterFromNotificataions(): Promise<any> {
+    return this.notificationService.unregisterFromNotificataions()
+  }
+
   isPlatformCordova() {
     return this.platform.is('cordova')
   }

--- a/src/app/core/services/notifications/notification.service.ts
+++ b/src/app/core/services/notifications/notification.service.ts
@@ -17,6 +17,8 @@ export abstract class NotificationService {
 
   abstract publish(type, limit?, notificationId?)
 
+  abstract unregisterFromNotificataions(): Promise<any>
+
   setLastNotificationUpdate(timestamp): Promise<void> {
     return this.storage.set(
       this.NOTIFICATION_STORAGE.LAST_NOTIFICATION_UPDATE,


### PR DESCRIPTION
-  Unregisters from Firebase on app reset, this will delete the current FCM token and stop notifications from arriving
- On app signup, this token will be auto initialised