### PR TITLE
Fix Firebase attribute prefix

### DIFF
--- a/src/app/core/services/config/config.service.ts
+++ b/src/app/core/services/config/config.service.ts
@@ -29,7 +29,7 @@ import { SubjectConfigService } from './subject-config.service'
 
 @Injectable()
 export class ConfigService {
-  ATTRIBUTE_KEY_PREFIX = 'att-'
+  ATTRIBUTE_KEY_PREFIX = 'att_'
 
   constructor(
     private schedule: ScheduleService,

--- a/src/app/core/services/usage/firebase-analytics.service.ts
+++ b/src/app/core/services/usage/firebase-analytics.service.ts
@@ -91,7 +91,7 @@ export class FirebaseAnalyticsService extends AnalyticsService {
         .map(([key, value]) => {
           return this.firebase.setUserProperty(
             this.crop(
-              keyPrefix ? keyPrefix + key : key,
+              this.formatUserPropertyKey(key, keyPrefix),
               24,
               `Firebase User Property name ${key} is too long, cropping`
             ),
@@ -103,6 +103,10 @@ export class FirebaseAnalyticsService extends AnalyticsService {
           )
         })
     ).then(() => this.remoteConfig.forceFetch())
+  }
+
+  formatUserPropertyKey(key: string, keyPrefix: string) {
+    return (keyPrefix ? keyPrefix + key : key).replace(/[\W]+/g, '')
   }
 
   setUserId(userId: string): Promise<any> {

--- a/src/app/core/services/usage/firebase-analytics.service.ts
+++ b/src/app/core/services/usage/firebase-analytics.service.ts
@@ -106,7 +106,7 @@ export class FirebaseAnalyticsService extends AnalyticsService {
   }
 
   formatUserPropertyKey(key: string, keyPrefix: string) {
-    return (keyPrefix ? keyPrefix + key : key).replace(/[\W]+/g, '')
+    return (keyPrefix ? keyPrefix + key : key).replace(/[\W]+/g, '_')
   }
 
   setUserId(userId: string): Promise<any> {


### PR DESCRIPTION
- Fix Firebase attribute prefix to be compliant with Firebase user properties rules (hyphens are not allowed)