### PR TITLE
Authenticate requests to Github

### DIFF
--- a/src/app/core/services/config/protocol.service.ts
+++ b/src/app/core/services/config/protocol.service.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../shared/models/github'
 import { ProtocolMetaData } from '../../../shared/models/protocol'
 import { sortObject } from '../../../shared/utilities/sort-object'
-import { GithubClientService } from '../misc/github-client.service'
+import { GithubClient } from '../misc/github-client.service'
 import { LogService } from '../misc/log.service'
 import { AnalyticsService } from '../usage/analytics.service'
 import { RemoteConfigService } from './remote-config.service'
@@ -30,7 +30,7 @@ export class ProtocolService {
 
   constructor(
     private config: SubjectConfigService,
-    private githubClient: GithubClientService,
+    private githubClient: GithubClient,
     private remoteConfig: RemoteConfigService,
     private logger: LogService,
     private analytics: AnalyticsService

--- a/src/app/core/services/config/questionnaire.service.ts
+++ b/src/app/core/services/config/questionnaire.service.ts
@@ -15,7 +15,7 @@ import {
 import { Question } from '../../../shared/models/question'
 import { Task } from '../../../shared/models/task'
 import { Utility } from '../../../shared/utilities/util'
-import { GithubClientService } from '../misc/github-client.service'
+import { GithubClient } from '../misc/github-client.service'
 import { LocalizationService } from '../misc/localization.service'
 import { LogService } from '../misc/log.service'
 import { StorageService } from '../storage/storage.service'
@@ -31,7 +31,7 @@ export class QuestionnaireService {
   constructor(
     private storage: StorageService,
     private localization: LocalizationService,
-    private githubClient: GithubClientService,
+    private githubClient: GithubClient,
     private util: Utility,
     private logger: LogService
   ) {}

--- a/src/app/core/services/misc/github-client.service.ts
+++ b/src/app/core/services/misc/github-client.service.ts
@@ -8,7 +8,7 @@ import { RemoteConfigService } from '../config/remote-config.service'
 import { LogService } from './log.service'
 
 @Injectable()
-export class GithubClientService {
+export class GithubClient {
   constructor(
     private http: HttpClient,
     private remoteConfig: RemoteConfigService,

--- a/src/app/core/services/misc/github-client.service.ts
+++ b/src/app/core/services/misc/github-client.service.ts
@@ -1,0 +1,39 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http'
+import { Injectable } from '@angular/core'
+
+import { DefaultGithubToken } from '../../../../assets/data/defaultConfig'
+import { ConfigKeys } from '../../../shared/enums/config'
+import { GithubContent } from '../../../shared/models/github'
+import { RemoteConfigService } from '../config/remote-config.service'
+
+@Injectable()
+export class GithubClientService {
+  constructor(
+    private http: HttpClient,
+    private remoteConfig: RemoteConfigService
+  ) {}
+
+  get(url): Promise<any> {
+    return this.remoteConfig
+      .read()
+      .then(config =>
+        config.getOrDefault(ConfigKeys.GITHUB_API_TOKEN, DefaultGithubToken)
+      )
+      .then(token =>
+        this.http
+          .get(url, {
+            headers: new HttpHeaders().set('Authorization', 'Bearer ' + token)
+          })
+          .toPromise()
+      )
+  }
+
+  getContent(url): Promise<any> {
+    return this.get(url).then((res: GithubContent) => {
+      const parsed = JSON.parse(atob(res.content))
+      if (!(parsed instanceof Array))
+        throw new Error('URL does not contain an array of questions')
+      return parsed
+    })
+  }
+}

--- a/src/app/pages/pages.module.ts
+++ b/src/app/pages/pages.module.ts
@@ -10,7 +10,7 @@ import { SubjectConfigService } from '../core/services/config/subject-config.ser
 import { KafkaService } from '../core/services/kafka/kafka.service'
 import { SchemaService } from '../core/services/kafka/schema.service'
 import { AlertService } from '../core/services/misc/alert.service'
-import { GithubClientService } from '../core/services/misc/github-client.service'
+import { GithubClient } from '../core/services/misc/github-client.service'
 import { LocalizationService } from '../core/services/misc/localization.service'
 import { FcmRestNotificationService } from '../core/services/notifications/fcm-rest-notification.service'
 import { FcmXmppNotificationService } from '../core/services/notifications/fcm-xmpp-notification.service'
@@ -75,7 +75,7 @@ import { SplashModule } from './splash/splash.module'
     MessageHandlerService,
     { provide: NotificationService, useClass: NotificationFactoryService },
     { provide: AnalyticsService, useClass: FirebaseAnalyticsService },
-    GithubClientService
+    GithubClient
   ]
 })
 export class PagesModule {}

--- a/src/app/pages/pages.module.ts
+++ b/src/app/pages/pages.module.ts
@@ -10,6 +10,7 @@ import { SubjectConfigService } from '../core/services/config/subject-config.ser
 import { KafkaService } from '../core/services/kafka/kafka.service'
 import { SchemaService } from '../core/services/kafka/schema.service'
 import { AlertService } from '../core/services/misc/alert.service'
+import { GithubClientService } from '../core/services/misc/github-client.service'
 import { LocalizationService } from '../core/services/misc/localization.service'
 import { FcmRestNotificationService } from '../core/services/notifications/fcm-rest-notification.service'
 import { FcmXmppNotificationService } from '../core/services/notifications/fcm-xmpp-notification.service'
@@ -73,7 +74,8 @@ import { SplashModule } from './splash/splash.module'
     AppServerService,
     MessageHandlerService,
     { provide: NotificationService, useClass: NotificationFactoryService },
-    { provide: AnalyticsService, useClass: FirebaseAnalyticsService }
+    { provide: AnalyticsService, useClass: FirebaseAnalyticsService },
+    GithubClientService
   ]
 })
 export class PagesModule {}

--- a/src/app/shared/enums/config.ts
+++ b/src/app/shared/enums/config.ts
@@ -32,6 +32,7 @@ export class ConfigKeys {
   static SKIPPABLE_QUESTIONNAIRE_TYPES = new ConfigKeys(
     'skippable_questionnaire_types'
   )
+  static GITHUB_API_TOKEN = new ConfigKeys('github_api_token')
 
   constructor(public value: string) {}
 

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -172,6 +172,9 @@ export const DefaultSchemaSpecEndpoint = [
   DefaultSchemaSpecPath
 ].join('/')
 
+// *The Github token used for accessing the Github API.
+export const DefaultGithubToken = ''
+
 // *The order in which participant attributes are matched to protocol endpoints; format: {attributeName: orderNumber}
 export const DefaultParticipantAttributeOrder = {
   'Human-readable-identifier': -1


### PR DESCRIPTION
- Add token authentication for requests to Github to access private repositories and bypass the rate limit
- Adds a new `GithubClient` to handle this
- Refactors `QuestionnaireService` to parse the url provided in the protocol.json file to use the Github API, since this is just in the format `http://raw.github...` 
- Updates `ProtocolService` and `QuestionnaireService` to use the new client

Solves #1303