### PR TITLE
Add support for header-only info screens

### DIFF
--- a/src/app/pages/questions/components/question/info-screen/info-screen.component.html
+++ b/src/app/pages/questions/components/question/info-screen/info-screen.component.html
@@ -1,4 +1,4 @@
-<div class="info-card">
+<div class="info-card" *ngIf="sections">
   <div class="content" #content scrollY="true" (scroll)="onScroll($event)">
     <div class="image-container">
       <img *ngIf="image" src="{{ image }}" class="image" alt="info-screen" />

--- a/src/app/pages/questions/components/question/info-screen/info-screen.component.ts
+++ b/src/app/pages/questions/components/question/info-screen/info-screen.component.ts
@@ -49,6 +49,7 @@ export class InfoScreenComponent implements OnInit, OnChanges {
   }
 
   initSections() {
+    if (!this.sections.length) return
     this.sections.map((item, i) => {
       if (item.label.includes('THINC-it'))
         this.image = 'assets/imgs/thincIt_app_icon.png'


### PR DESCRIPTION
- Hide info card when only the header is present for info screens
<img width="157" alt="Screen Shot 2021-06-28 at 4 22 49 PM" src="https://user-images.githubusercontent.com/16977973/123662230-291fa600-d82d-11eb-806a-45d887a534df.png"> to -> <img width="157" alt="Screen Shot 2021-06-28 at 4 21 55 PM" src="https://user-images.githubusercontent.com/16977973/123662237-2ae96980-d82d-11eb-84ee-a736563dee13.png">


