### PR TITLE
Pull Github content from the app server

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="556" id="org.phidatalab.radar_armt" ios-CFBundleIdentifier="org.phidatalab.radar-armt" ios-CFBundleVersion="1" version="1.2.0-alpha" xmlns:android="http://schemas.android.com/apk/res/android">
+<widget android-versionCode="558" id="org.phidatalab.radar_armt" ios-CFBundleIdentifier="org.phidatalab.radar-armt" ios-CFBundleVersion="1" version="2.0.0-alpha" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>RADAR Questionnaire</name>
     <description>An application that collects active data for research.</description>
     <author email="radar-base@kcl.ac.uk" href="http://radar-base.org/">RADAR-Base</author>

--- a/src/app/core/services/app-server/app-server.service.ts
+++ b/src/app/core/services/app-server/app-server.service.ts
@@ -50,7 +50,7 @@ export class AppServerService {
             subjectId,
             projectId,
             enrolmentDate,
-            'fcmToken'
+            fcmToken
           )
         )
       )

--- a/src/app/core/services/app-server/app-server.service.ts
+++ b/src/app/core/services/app-server/app-server.service.ts
@@ -21,6 +21,7 @@ export class AppServerService {
   private APP_SERVER_URL
   SUBJECT_PATH = 'users'
   PROJECT_PATH = 'projects'
+  GITHUB_CONTENT_PATH = 'github/content'
 
   constructor(
     public storage: StorageService,
@@ -49,7 +50,7 @@ export class AppServerService {
             subjectId,
             projectId,
             enrolmentDate,
-            fcmToken
+            'fcmToken'
           )
         )
       )
@@ -181,6 +182,18 @@ export class AppServerService {
           updatedSubject,
           { headers }
         )
+        .toPromise()
+    })
+  }
+
+  // NOTE: This method fetches from Github through the App Server.
+  fetchFromGithub(githubUrl: string) {
+    return this.getHeaders().then(headers => {
+      return this.http
+        .get(urljoin(this.APP_SERVER_URL, this.GITHUB_CONTENT_PATH), {
+          headers,
+          params: { url: githubUrl }
+        })
         .toPromise()
     })
   }

--- a/src/app/core/services/config/protocol.service.spec.ts
+++ b/src/app/core/services/config/protocol.service.spec.ts
@@ -3,17 +3,19 @@ import { TestBed } from '@angular/core/testing'
 
 import {
   FirebaseAnalyticsServiceMock,
+  GithubClientMock,
   LogServiceMock,
   RemoteConfigServiceMock,
   SubjectConfigServiceMock,
   UtilityMock
 } from '../../../shared/testing/mock-services'
+import { Utility } from '../../../shared/utilities/util'
+import { GithubClient } from '../misc/github-client.service'
 import { LogService } from '../misc/log.service'
 import { AnalyticsService } from '../usage/analytics.service'
 import { ProtocolService } from './protocol.service'
 import { RemoteConfigService } from './remote-config.service'
 import { SubjectConfigService } from './subject-config.service'
-import { Utility } from '../../../shared/utilities/util'
 
 describe('ProtocolService', () => {
   let service
@@ -31,7 +33,8 @@ describe('ProtocolService', () => {
           provide: AnalyticsService,
           useClass: FirebaseAnalyticsServiceMock
         },
-        { provide: Utility, useClass: UtilityMock }
+        { provide: Utility, useClass: UtilityMock },
+        { provide: GithubClient, useClass: GithubClientMock }
       ]
     })
   )
@@ -43,5 +46,4 @@ describe('ProtocolService', () => {
   it('should create', () => {
     expect(service instanceof ProtocolService).toBe(true)
   })
-
 })

--- a/src/app/core/services/config/protocol.service.ts
+++ b/src/app/core/services/config/protocol.service.ts
@@ -44,7 +44,7 @@ export class ProtocolService {
           new Map(Object.entries(attributes))
         ).catch(() => this.getProtocolPathInTree(tree, DefaultProtocolPath))
       )
-      .then((url: string) => this.githubClient.get(url))
+      .then((url: string) => this.githubClient.getRaw(url))
       .then((res: GithubContent) => ({
         protocol: atob(res.content),
         url: res.url
@@ -89,7 +89,7 @@ export class ProtocolService {
   }
 
   getChildTree(child: GithubTreeChild): Promise<GithubTree> {
-    return this.githubClient.get(child.url) as Promise<GithubTree>
+    return this.githubClient.getRaw(child.url) as Promise<GithubTree>
   }
 
   matchTreeWithAttributeKey(
@@ -119,11 +119,11 @@ export class ProtocolService {
       this.getRootTreeHashUrl()
     ])
       .then(([projectName, url]) =>
-        this.githubClient.get(url).then((res: GithubTree) => {
+        this.githubClient.getRaw(url).then((res: GithubTree) => {
           const project = res.tree.find(c => c.path == projectName)
           if (project == null || project == undefined)
             throw new Error('Unable to find project in repository.')
-          return this.githubClient.get(project.url) as Promise<GithubTree>
+          return this.githubClient.getRaw(project.url) as Promise<GithubTree>
         })
       )
       .then(projectChild => projectChild.tree)
@@ -137,7 +137,7 @@ export class ProtocolService {
       .then(([branch, repo]) => {
         const treeUrl = [GIT_API_URI, repo, this.GIT_BRANCHES, branch].join('/')
         return this.githubClient
-          .get(treeUrl)
+          .getRaw(treeUrl)
           .then((res: any) => res.commit.commit.tree.url)
       })
   }

--- a/src/app/core/services/config/protocol.service.ts
+++ b/src/app/core/services/config/protocol.service.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../shared/models/github'
 import { ProtocolMetaData } from '../../../shared/models/protocol'
 import { sortObject } from '../../../shared/utilities/sort-object'
-import { GithubClientService } from '../misc/github-client.service'
+import { GithubClient } from '../misc/github-client.service'
 import { LogService } from '../misc/log.service'
 import { AnalyticsService } from '../usage/analytics.service'
 import { RemoteConfigService } from './remote-config.service'
@@ -30,7 +30,7 @@ export class ProtocolService {
 
   constructor(
     private config: SubjectConfigService,
-    private githubClient: GithubClientService,
+    private githubClient: GithubClient,
     private remoteConfig: RemoteConfigService,
     private logger: LogService,
     private analytics: AnalyticsService

--- a/src/app/core/services/config/questionnaire.service.spec.ts
+++ b/src/app/core/services/config/questionnaire.service.spec.ts
@@ -2,12 +2,14 @@ import { HttpClient, HttpHandler } from '@angular/common/http'
 import { TestBed } from '@angular/core/testing'
 
 import {
+  GithubClientMock,
   LocalizationServiceMock,
   LogServiceMock,
   StorageServiceMock,
   UtilityMock
 } from '../../../shared/testing/mock-services'
 import { Utility } from '../../../shared/utilities/util'
+import { GithubClient } from '../misc/github-client.service'
 import { LocalizationService } from '../misc/localization.service'
 import { LogService } from '../misc/log.service'
 import { StorageService } from '../storage/storage.service'
@@ -25,7 +27,8 @@ describe('QuestionnaireService', () => {
         { provide: StorageService, useClass: StorageServiceMock },
         { provide: LocalizationService, useClass: LocalizationServiceMock },
         { provide: LogService, useClass: LogServiceMock },
-        { provide: Utility, useClass: UtilityMock }
+        { provide: Utility, useClass: UtilityMock },
+        { provide: GithubClient, useClass: GithubClientMock }
       ]
     })
   )

--- a/src/app/core/services/config/questionnaire.service.ts
+++ b/src/app/core/services/config/questionnaire.service.ts
@@ -15,7 +15,7 @@ import {
 import { Question } from '../../../shared/models/question'
 import { Task } from '../../../shared/models/task'
 import { Utility } from '../../../shared/utilities/util'
-import { GithubClientService } from '../misc/github-client.service'
+import { GithubClient } from '../misc/github-client.service'
 import { LocalizationService } from '../misc/localization.service'
 import { LogService } from '../misc/log.service'
 import { StorageService } from '../storage/storage.service'
@@ -31,7 +31,7 @@ export class QuestionnaireService {
   constructor(
     private storage: StorageService,
     private localization: LocalizationService,
-    private githubClient: GithubClientService,
+    private githubClient: GithubClient,
     private util: Utility,
     private logger: LogService
   ) {}

--- a/src/app/core/services/misc/github-client.service.ts
+++ b/src/app/core/services/misc/github-client.service.ts
@@ -1,50 +1,19 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http'
 import { Injectable } from '@angular/core'
 
-import { DefaultGithubToken } from '../../../../assets/data/defaultConfig'
-import { ConfigKeys } from '../../../shared/enums/config'
 import { GithubContent } from '../../../shared/models/github'
-import { RemoteConfigService } from '../config/remote-config.service'
-import { LogService } from './log.service'
+import { AppServerService } from '../app-server/app-server.service'
 
 @Injectable()
 export class GithubClient {
-  constructor(
-    private http: HttpClient,
-    private remoteConfig: RemoteConfigService,
-    private logger: LogService
-  ) {}
+  constructor(private appServerService: AppServerService) {}
 
-  get(url): Promise<any> {
-    return this.readRemoteConfig()
-      .then(config =>
-        config
-          ? config.getOrDefault(ConfigKeys.GITHUB_API_TOKEN, DefaultGithubToken)
-          : DefaultGithubToken
-      )
-      .then(token => {
-        return this.http
-          .get(url, {
-            headers: token
-              ? new HttpHeaders().set('Authorization', 'Bearer ' + token)
-              : {}
-          })
-          .toPromise()
-      })
+  getRaw(url): Promise<any> {
+    return this.appServerService.fetchFromGithub(url)
   }
 
   getContent(url): Promise<any> {
-    return this.get(url).then((res: GithubContent) => {
-      const parsed = JSON.parse(atob(res.content))
-      if (!(parsed instanceof Array))
-        throw new Error('URL does not contain an array of questions')
-      return parsed
-    })
-  }
-
-  readRemoteConfig() {
-    return this.remoteConfig.read().catch(e => {
-      throw this.logger.error('Failed to fetch Firebase config', e)
+    return this.getRaw(url).then((res: GithubContent) => {
+      return JSON.parse(atob(res.content))
     })
   }
 }

--- a/src/app/core/services/misc/github-client.service.ts
+++ b/src/app/core/services/misc/github-client.service.ts
@@ -8,7 +8,7 @@ import { RemoteConfigService } from '../config/remote-config.service'
 import { LogService } from './log.service'
 
 @Injectable()
-export class GithubClientService {
+export class GithubClient {
   constructor(
     private http: HttpClient,
     private remoteConfig: RemoteConfigService,

--- a/src/app/core/services/misc/github-client.service.ts
+++ b/src/app/core/services/misc/github-client.service.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http'
 import { Injectable } from '@angular/core'
 
 import { GithubContent } from '../../../shared/models/github'
@@ -8,11 +9,15 @@ import { AppServerService } from '../app-server/app-server.service'
 export class GithubClient {
   constructor(
     private appServerService: AppServerService,
-    private util: Utility
+    private util: Utility,
+    private http: HttpClient
   ) {}
 
   getRaw(url): Promise<any> {
-    return this.appServerService.fetchFromGithub(url)
+    return this.appServerService.fetchFromGithub(url).catch(e => {
+      if (e.status == 404) return this.http.get(url).toPromise()
+      else throw e
+    })
   }
 
   getContent(url): Promise<any> {

--- a/src/app/core/services/misc/github-client.service.ts
+++ b/src/app/core/services/misc/github-client.service.ts
@@ -1,11 +1,15 @@
 import { Injectable } from '@angular/core'
 
 import { GithubContent } from '../../../shared/models/github'
+import { Utility } from '../../../shared/utilities/util'
 import { AppServerService } from '../app-server/app-server.service'
 
 @Injectable()
 export class GithubClient {
-  constructor(private appServerService: AppServerService) {}
+  constructor(
+    private appServerService: AppServerService,
+    private util: Utility
+  ) {}
 
   getRaw(url): Promise<any> {
     return this.appServerService.fetchFromGithub(url)
@@ -13,7 +17,7 @@ export class GithubClient {
 
   getContent(url): Promise<any> {
     return this.getRaw(url).then((res: GithubContent) => {
-      return JSON.parse(atob(res.content))
+      return JSON.parse(this.util.base64ToUnicode(res.content))
     })
   }
 }

--- a/src/app/core/services/misc/github-client.service.ts
+++ b/src/app/core/services/misc/github-client.service.ts
@@ -1,0 +1,39 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http'
+import { Injectable } from '@angular/core'
+
+import { DefaultGithubToken } from '../../../../assets/data/defaultConfig'
+import { ConfigKeys } from '../../../shared/enums/config'
+import { GithubContent } from '../../../shared/models/github'
+import { RemoteConfigService } from '../config/remote-config.service'
+
+@Injectable()
+export class GithubClientService {
+  constructor(
+    private http: HttpClient,
+    private remoteConfig: RemoteConfigService
+  ) {}
+
+  get(url): Promise<any> {
+    return this.remoteConfig
+      .read()
+      .then(config =>
+        config.getOrDefault(ConfigKeys.GITHUB_API_TOKEN, DefaultGithubToken)
+      )
+      .then(token =>
+        this.http
+          .get(url, {
+            headers: new HttpHeaders().set('Authorization', 'Bearer ' + token)
+          })
+          .toPromise()
+      )
+  }
+
+  getContent(url): Promise<any> {
+    return this.get(url).then((res: GithubContent) => {
+      const parsed = JSON.parse(atob(res.content))
+      if (!(parsed instanceof Array))
+        throw new Error('URL does not contain an array of questions')
+      return parsed
+    })
+  }
+}

--- a/src/app/core/services/schedule/schedule-generator.service.ts
+++ b/src/app/core/services/schedule/schedule-generator.service.ts
@@ -48,20 +48,18 @@ export class ScheduleGeneratorService {
       this.questionnaire.getAssessments(AssessmentType.SCHEDULED),
       this.fetchScheduleYearCoverage()
     ]).then(([assessments]) => {
-      const schedule: Task[] = assessments.reduce((list, assessment) => {
-        const completed = completedTasks.filter(t => t.name == assessment.name)
-        return (
-          list.concat(
-            this.buildTasksForSingleAssessment(
-              assessment,
-              list.length,
-              refTimestamp,
-              AssessmentType.SCHEDULED
-            )
-          ),
-          []
-        )
-      })
+      const schedule: Task[] = assessments.reduce(
+        (list: Task[], assessment) => {
+          const tasks = this.buildTasksForSingleAssessment(
+            assessment,
+            list.length,
+            refTimestamp,
+            AssessmentType.SCHEDULED
+          )
+          return list.concat(tasks)
+        },
+        []
+      )
       // NOTE: Check for completed tasks
       const res = this.updateScheduleWithCompletedTasks(
         schedule,

--- a/src/app/core/services/schedule/schedule.service.ts
+++ b/src/app/core/services/schedule/schedule.service.ts
@@ -142,7 +142,7 @@ export class ScheduleService {
       .then(res =>
         Promise.all([
           this.setTasks(AssessmentType.SCHEDULED, res.schedule),
-          this.setCompletedTasks(res.completed)
+          this.setCompletedTasks(res.completed ? res.completed : [])
         ])
       )
   }

--- a/src/app/pages/pages.module.ts
+++ b/src/app/pages/pages.module.ts
@@ -10,7 +10,7 @@ import { SubjectConfigService } from '../core/services/config/subject-config.ser
 import { KafkaService } from '../core/services/kafka/kafka.service'
 import { SchemaService } from '../core/services/kafka/schema.service'
 import { AlertService } from '../core/services/misc/alert.service'
-import { GithubClientService } from '../core/services/misc/github-client.service'
+import { GithubClient } from '../core/services/misc/github-client.service'
 import { LocalizationService } from '../core/services/misc/localization.service'
 import { FcmRestNotificationService } from '../core/services/notifications/fcm-rest-notification.service'
 import { FcmXmppNotificationService } from '../core/services/notifications/fcm-xmpp-notification.service'
@@ -75,7 +75,7 @@ import { SplashModule } from './splash/splash.module'
     MessageHandlerService,
     { provide: NotificationService, useClass: NotificationFactoryService },
     { provide: AnalyticsService, useClass: FirebaseAnalyticsService },
-    GithubClientService
+    GithubClient
   ]
 })
 export class PagesModule {}

--- a/src/app/pages/pages.module.ts
+++ b/src/app/pages/pages.module.ts
@@ -10,6 +10,7 @@ import { SubjectConfigService } from '../core/services/config/subject-config.ser
 import { KafkaService } from '../core/services/kafka/kafka.service'
 import { SchemaService } from '../core/services/kafka/schema.service'
 import { AlertService } from '../core/services/misc/alert.service'
+import { GithubClientService } from '../core/services/misc/github-client.service'
 import { LocalizationService } from '../core/services/misc/localization.service'
 import { FcmRestNotificationService } from '../core/services/notifications/fcm-rest-notification.service'
 import { FcmXmppNotificationService } from '../core/services/notifications/fcm-xmpp-notification.service'
@@ -73,7 +74,8 @@ import { SplashModule } from './splash/splash.module'
     AppServerService,
     MessageHandlerService,
     { provide: NotificationService, useClass: NotificationFactoryService },
-    { provide: AnalyticsService, useClass: FirebaseAnalyticsService }
+    { provide: AnalyticsService, useClass: FirebaseAnalyticsService },
+    GithubClientService
   ]
 })
 export class PagesModule {}

--- a/src/app/pages/questions/components/question/matrix-radio-input/matrix-radio-input.component.ts
+++ b/src/app/pages/questions/components/question/matrix-radio-input/matrix-radio-input.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output
+} from '@angular/core'
 
 import { Item, Response } from '../../../../../shared/models/question'
 
@@ -8,7 +15,7 @@ let uniqueID = 0
   selector: 'matrix-radio-input',
   templateUrl: 'matrix-radio-input.component.html'
 })
-export class MatrixRadioInputComponent implements OnInit {
+export class MatrixRadioInputComponent implements OnInit, OnChanges {
   @Output()
   valueChange: EventEmitter<number> = new EventEmitter<number>()
 

--- a/src/app/shared/enums/config.ts
+++ b/src/app/shared/enums/config.ts
@@ -33,6 +33,8 @@ export class ConfigKeys {
     'skippable_questionnaire_types'
   )
 
+  static GITHUB_FETCH_STRATEGY = new ConfigKeys('github_fetch_strategy')
+
   constructor(public value: string) {}
 
   toString() {

--- a/src/app/shared/enums/config.ts
+++ b/src/app/shared/enums/config.ts
@@ -32,7 +32,6 @@ export class ConfigKeys {
   static SKIPPABLE_QUESTIONNAIRE_TYPES = new ConfigKeys(
     'skippable_questionnaire_types'
   )
-  static GITHUB_API_TOKEN = new ConfigKeys('github_api_token')
 
   constructor(public value: string) {}
 

--- a/src/app/shared/enums/config.ts
+++ b/src/app/shared/enums/config.ts
@@ -32,6 +32,7 @@ export class ConfigKeys {
   static SKIPPABLE_QUESTIONNAIRE_TYPES = new ConfigKeys(
     'skippable_questionnaire_types'
   )
+  static GITHUB_API_TOKEN = new ConfigKeys('github_api_token')
 
   constructor(public value: string) {}
 

--- a/src/app/shared/models/github.ts
+++ b/src/app/shared/models/github.ts
@@ -22,3 +22,8 @@ export interface GithubContent {
   size: number
   url: string
 }
+
+export enum GithubFetchStrategy {
+  DEFAULT = 'default',
+  APP_SERVER = 'appserver'
+}

--- a/src/app/shared/testing/mock-services.ts
+++ b/src/app/shared/testing/mock-services.ts
@@ -45,3 +45,4 @@ export class JwtHelperServiceMock {}
 export class WebIntentMock {}
 export class AppServerServiceMock {}
 export class MessageHandlerServiceMock {}
+export class GithubClientMock {}

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -172,9 +172,6 @@ export const DefaultSchemaSpecEndpoint = [
   DefaultSchemaSpecPath
 ].join('/')
 
-// *The Github token used for accessing the Github API.
-export const DefaultGithubToken = ''
-
 // *The order in which participant attributes are matched to protocol endpoints; format: {attributeName: orderNumber}
 export const DefaultParticipantAttributeOrder = {
   'Human-readable-identifier': -1

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -145,6 +145,9 @@ export const DefaultNotificationTtlMinutes: number = 10
 
 export const GIT_API_URI = 'https://api.github.com/repos'
 
+// *The Github content fetching mechanism, if this is done by a direct request to Github or a request through the app server. (REMOTE CONFIG KEY: `github_fetch_strategy`, VALUES: `default` (direct to Github) or `appserver`)
+export const DefaultGithubFetchStrategy = 'default'
+
 // *The Github repository where the protocols are located (REMOTE CONFIG KEY: `protocol_repo`)
 export const DefaultProtocolGithubRepo = 'RADAR-Base/RADAR-aRMT-protocols'
 

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -172,6 +172,9 @@ export const DefaultSchemaSpecEndpoint = [
   DefaultSchemaSpecPath
 ].join('/')
 
+// *The Github token used for accessing the Github API.
+export const DefaultGithubToken = ''
+
 // *The order in which participant attributes are matched to protocol endpoints; format: {attributeName: orderNumber}
 export const DefaultParticipantAttributeOrder = {
   'Human-readable-identifier': -1

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -16,7 +16,7 @@ import { DefaultSourceProducerAndSecretExport } from './secret'
 export const DefaultPlatformInstance = 'RADAR-CNS'
 
 // *Default app version
-export const DefaultAppVersion = '1.0.0-alpha'
+export const DefaultAppVersion = '2.0.0-alpha'
 
 // *Default Android package name
 export const DefaultPackageName = 'org.phidatalab.radar_armt'


### PR DESCRIPTION
- Adds new Github client to pull Github content (with authentication) from the app server instead of keeping the token in the app or in the remote config
- Refactors `QuestionnaireService` to parse the url provided in the protocol.json file to use the Github API, since this is just in the format `http://raw.github...` 
- Updates `ProtocolService` and `QuestionnaireService` to use the new client