### PR TITLE
Fix storage incompatibilities with Android 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,14 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Install NDK
-        run: cp -R /usr/local/lib/android/sdk/ndk-bundle /usr/local/lib/android/sdk/ndk/21.4.7075529
+      - name: Setup Android Tools
+        uses: maxim-lobanov/setup-android-tools@v1
+        with:
+          packages: |
+            platforms;android-29
+            platforms;android-30
+            platforms;android-31
+            ndk;21.4.7075529
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
 
       - name: Setup Node
         uses: actions/setup-node@v2
@@ -72,7 +75,7 @@ jobs:
 
       - name: Install app dependencies
         run: yarn install
-
+s
       - name: Run unit tests
         run: yarn run test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,9 +52,6 @@ jobs:
       - name: Fix Android directories
         run: mkdir -p .android && touch ~/.android/repositories.cfg
 
-      - name: Fix Android issue
-        run: yes | sdkmanager "platforms;android-27"
-
       - name: Setup Node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,9 @@ jobs:
             platforms;android-31
             ndk;21.4.7075529
 
+      - name: Fix Android directories
+        run: export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.4.7075529
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
   # Build and test the code
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -46,15 +46,10 @@ jobs:
         with:
           packages: |
             platforms;android-29
-            platforms;android-30
-            platforms;android-31
             ndk;21.4.7075529
 
       - name: Fix Android directories
         run: export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.4.7075529
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           java-version: 1.8
 
       - name: Install NDK
-        run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.4.7075529" --sdk_root=${ANDROID_SDK_ROOT}
+        run: cp /usr/local/lib/android/sdk/ndk-bundle /usr/local/lib/android/sdk/ndk/21.4.7075529
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,14 +44,6 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
-      - name: Setup Android Tools
-        uses: maxim-lobanov/setup-android-tools@v1
-        with:
-          packages: |
-            platforms;android-29
-            platforms;android-31
-            ndk;21.4.7075529
-
       - name: Fix Android directories
         run: rm -R /usr/local/lib/android/sdk/build-tools/31.0.0/
 
@@ -97,9 +89,6 @@ jobs:
         run: |
           cordova prepare android && \
           yarn install
-
-      - name: Prepare Android app
-        run: ionic cordova build android
 
       - name: Build Android app
         uses: maierj/fastlane-action@v2.0.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     branches: [master, dev]
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # Build and test the code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
             ndk;21.4.7075529
 
       - name: Fix Android directories
-        run: export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.4.7075529
+        run: mkdir -p .android && touch ~/.android/repositories.cfg
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,10 +46,14 @@ jobs:
         with:
           packages: |
             platforms;android-29
+            platforms;android-31
             ndk;21.4.7075529
 
       - name: Fix Android directories
         run: mkdir -p .android && touch ~/.android/repositories.cfg
+
+      - name: Fix Android issue
+        run: yes | sdkmanager "platforms;android-27"
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [master, dev]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # Build and test the code
@@ -37,7 +40,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
@@ -72,7 +75,7 @@ jobs:
 
       - name: Install app dependencies
         run: yarn install
-s
+
       - name: Run unit tests
         run: yarn run test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: Install NDK
+        run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.4.7075529" --sdk_root=${ANDROID_SDK_ROOT}
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
   # Build and test the code
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
             ndk;21.4.7075529
 
       - name: Fix Android directories
-        run: rm -R /usr/local/lib/android/sdk/build-tools/
+        run: rm -R /usr/local/lib/android/sdk/build-tools/31.0.0/
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,9 @@ jobs:
           cordova prepare android && \
           yarn install
 
+      - name: Prepare Android app
+        run: ionic cordova build android
+
       - name: Build Android app
         uses: maierj/fastlane-action@v2.0.1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
       - name: Setup Android Tools
         uses: maxim-lobanov/setup-android-tools@v1
         with:
@@ -50,7 +53,7 @@ jobs:
             ndk;21.4.7075529
 
       - name: Fix Android directories
-        run: mkdir -p .android && touch ~/.android/repositories.cfg
+        run: rm -R /usr/local/lib/android/sdk/build-tools/
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           java-version: 1.8
 
       - name: Install NDK
-        run: cp /usr/local/lib/android/sdk/ndk-bundle /usr/local/lib/android/sdk/ndk/21.4.7075529
+        run: cp -R /usr/local/lib/android/sdk/ndk-bundle /usr/local/lib/android/sdk/ndk/21.4.7075529
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
         uses: maierj/fastlane-action@v2.0.1
         with:
           lane: 'android deploy'
-          options: '{ "keystore_path": ${KEYSTORE_PATH}, "keystore_password": ${KEYSTORE_PASS}, "keystore_alias": ${KEYSTORE_ALIAS}, "package_name": ${PACKAGE_NAME_ANDROID}, "track": ${PLAYSTORE_TRACK}, "json_key": ${PLAYSTORE_SERVICE_KEY} }'
+          options: '{ "keystore_path": "${KEYSTORE_PATH}", "keystore_password": "${KEYSTORE_PASS}", "keystore_alias": "${KEYSTORE_ALIAS}", "package_name": "${PACKAGE_NAME_ANDROID}", "track": "${PLAYSTORE_TRACK}", "json_key": "${PLAYSTORE_SERVICE_KEY}" }'
         env:
           KEYSTORE_PATH: ${{env.KEYSTORE_PATH}}
           KEYSTORE_PASS: ${{secrets.KEYSTORE_PASS}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Fix Android directories
+        run: rm -R /usr/local/lib/android/sdk/build-tools/31.0.0/
+
       - name: Setup Node
         uses: actions/setup-node@v2
         with:

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="559" id="org.phidatalab.radar_armt" ios-CFBundleIdentifier="org.phidatalab.radar-armt" ios-CFBundleVersion="1" version="2.0.1-alpha" xmlns:android="http://schemas.android.com/apk/res/android">
+<widget android-versionCode="560" id="org.phidatalab.radar_armt" ios-CFBundleIdentifier="org.phidatalab.radar-armt" ios-CFBundleVersion="1" version="2.0.2-alpha" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>RADAR Questionnaire</name>
     <description>An application that collects active data for research.</description>
     <author email="radar-base@kcl.ac.uk" href="http://radar-base.org/">RADAR-Base</author>
@@ -50,6 +50,7 @@
         <custom-config-file parent="./application" target="AndroidManifest.xml">
             <meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/notification_icon" />
         </custom-config-file>
+        <custom-preference name="android-manifest/@android:requestLegacyExternalStorage" value="true" />
     </platform>
     <platform name="ios">
         <feature name="CDVWKWebViewEngine">

--- a/config.xml
+++ b/config.xml
@@ -149,7 +149,7 @@
         <variable name="IOS_SHOULD_ESTABLISH_DIRECT_CHANNEL" value="true" />
     </plugin>
     <plugin name="cordova-plugin-androidx-adapter" spec="^1.1.0" />
-    <plugin name="cordova-plugin-background-mode-fixes" spec="^0.7.6" />
+    <plugin name="cordova-plugin-background-mode" spec="git+https://bitbucket.org/TheBosZ/cordova-plugin-run-in-background.git" />
     <plugin name="com-darryncampbell-cordova-plugin-intent" spec="^2.0.0" />
     <plugin name="cordova-plugin-ionic-keyboard" spec="^2.2.0" />
     <plugin name="cordova-custom-config" spec="^5.1.0" />

--- a/config.xml
+++ b/config.xml
@@ -50,7 +50,8 @@
         <custom-config-file parent="./application" target="AndroidManifest.xml">
             <meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/notification_icon" />
         </custom-config-file>
-        <custom-preference name="android-manifest/@android:requestLegacyExternalStorage" value="true" />
+        <custom-preference name="android-manifest/application/@android:requestLegacyExternalStorage" value="true" />
+        <custom-preference name="android-manifest/application/@android:usesCleartextTraffic" value="true" />
     </platform>
     <platform name="ios">
         <feature name="CDVWKWebViewEngine">

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "cordova-plugin-android-permissions": "^1.0.0",
     "cordova-plugin-androidx-adapter": "^1.1.3",
     "cordova-plugin-app-version": "^0.1.12",
-    "cordova-plugin-background-mode-fixes": "^0.7.6",
     "cordova-plugin-badge": "^0.8.8",
     "cordova-plugin-camera": "^4.0.3",
     "cordova-plugin-device": "^2.0.3",
@@ -140,6 +139,7 @@
     "codelyzer": "^5.2.2",
     "cordova-android": "^9.0.0",
     "cordova-ios": "5.1.1",
+    "cordova-plugin-background-mode": "git+https://bitbucket.org/TheBosZ/cordova-plugin-run-in-background.git",
     "cordova-plugin-firebasex": "git+https://github.com/mpgxvii/cordova-plugin-firebasex.git#cli_build",
     "cordova-plugin-ionic-webview": "^4.2.1",
     "cordova-plugin-network-information": "git+https://github.com/apache/cordova-plugin-network-information.git",
@@ -224,7 +224,6 @@
       "cordova-plugin-file": {},
       "cordova-plugin-insomnia": {},
       "cordova-plugin-androidx-adapter": {},
-      "cordova-plugin-background-mode-fixes": {},
       "com-darryncampbell-cordova-plugin-intent": {},
       "cordova-plugin-ionic-keyboard": {},
       "cordova-plugin-network-information": {},
@@ -250,7 +249,8 @@
       },
       "cordova-plugin-ionic-webview": {
         "ANDROID_SUPPORT_ANNOTATIONS_VERSION": "27.+"
-      }
+      },
+      "cordova-plugin-background-mode": {}
     }
   },
   "ionic_enable_lint": false,

--- a/src/app/core/containers/app.component.ts
+++ b/src/app/core/containers/app.component.ts
@@ -24,12 +24,8 @@ export class AppComponent {
     this.platform.ready().then(() => {
       this.accessibility.usePreferredTextZoom(false)
       this.statusBar.hide()
-      this.notificationService
-        .init()
-        .then(() => this.notificationService.permissionCheck())
-        .catch()
-        .then(() => (this.isAppInitialized = true))
-        .then(() => this.splashScreen.hide())
+      this.isAppInitialized = true
+      this.splashScreen.hide()
     })
   }
 }

--- a/src/app/core/services/app-server/app-server.service.ts
+++ b/src/app/core/services/app-server/app-server.service.ts
@@ -159,7 +159,7 @@ export class AppServerService {
             timezone: moment.tz.guess(),
             language: this.localization.getLanguage().value
           },
-          { headers }
+          { headers, params: { forceFcmToken: 'true' } }
         )
         .toPromise()
     )
@@ -180,7 +180,7 @@ export class AppServerService {
             subjectId
           ),
           updatedSubject,
-          { headers }
+          { headers, params: { forceFcmToken: 'true' } }
         )
         .toPromise()
     })

--- a/src/app/core/services/app-server/app-server.service.ts
+++ b/src/app/core/services/app-server/app-server.service.ts
@@ -80,7 +80,7 @@ export class AppServerService {
   addProjectIfMissing(projectId): Promise<any> {
     return this.getProject(projectId).catch(e => {
       if (e.status == 404) return this.addProjectToServer(projectId)
-      else return
+      else throw e
     })
   }
 
@@ -137,7 +137,7 @@ export class AppServerService {
             enrolmentDate,
             fcmToken
           )
-        else return
+        else throw e
       })
   }
 

--- a/src/app/core/services/config/remote-config.service.ts
+++ b/src/app/core/services/config/remote-config.service.ts
@@ -114,6 +114,7 @@ export class FirebaseRemoteConfigService extends RemoteConfigService {
   ) {
     super(storage)
     this.configSubject = new BehaviorSubject(new EmptyRemoteConfig())
+    this.firebase.setConfigSettings({ fetchTimeout: 10 })
   }
 
   forceFetch(): Promise<RemoteConfig> {

--- a/src/app/pages/splash/services/splash.service.ts
+++ b/src/app/pages/splash/services/splash.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core'
 
 import { DefaultNumberOfCompletionLogsToSend } from '../../../../assets/data/defaultConfig'
 import { ConfigService } from '../../../core/services/config/config.service'
+import { NotificationService } from '../../../core/services/notifications/notification.service'
 import { ScheduleService } from '../../../core/services/schedule/schedule.service'
 import { TokenService } from '../../../core/services/token/token.service'
 import { UsageService } from '../../../core/services/usage/usage.service'
@@ -12,7 +13,8 @@ export class SplashService {
     private config: ConfigService,
     private token: TokenService,
     private schedule: ScheduleService,
-    private usage: UsageService
+    private usage: UsageService,
+    private notificationService: NotificationService
   ) {}
 
   evalEnrolment() {
@@ -20,7 +22,11 @@ export class SplashService {
   }
 
   loadConfig() {
-    return this.token.refresh().then(() => this.config.fetchConfigState())
+    return this.notificationService
+      .init()
+      .then(() => this.notificationService.permissionCheck())
+      .then(() => this.token.refresh())
+      .then(() => this.config.fetchConfigState())
   }
 
   isAppUpdateAvailable() {

--- a/src/app/pages/splash/services/splash.service.ts
+++ b/src/app/pages/splash/services/splash.service.ts
@@ -22,10 +22,10 @@ export class SplashService {
   }
 
   loadConfig() {
-    return this.notificationService
-      .init()
+    return this.token
+      .refresh()
+      .then(() => this.notificationService.init())
       .then(() => this.notificationService.permissionCheck())
-      .then(() => this.token.refresh())
       .then(() => this.config.fetchConfigState())
   }
 

--- a/src/app/shared/testing/mock-services.ts
+++ b/src/app/shared/testing/mock-services.ts
@@ -35,7 +35,11 @@ export class KafkaServiceMock {}
 export class LocalizationServiceMock {}
 export class FirebaseAnalyticsServiceMock {}
 export class UtilityMock {}
-export class FirebaseMock {}
+export class FirebaseMock {
+  setConfigSettings(settings: any) {
+    return
+  }
+}
 export class AppVersionMock {}
 export class SchemaServiceMock {}
 export class NotificationGeneratorServiceMock {}

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -15,7 +15,7 @@ import { Localisations } from './localisations'
 export const DefaultPlatformInstance = 'RADAR-CNS'
 
 // *Default app version
-export const DefaultAppVersion = '2.0.1-alpha'
+export const DefaultAppVersion = '2.0.2-alpha'
 
 // *Default Android package name
 export const DefaultPackageName = 'org.phidatalab.radar_armt'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4066,10 +4066,9 @@ cordova-plugin-app-version@^0.1.12:
   resolved "https://registry.yarnpkg.com/cordova-plugin-app-version/-/cordova-plugin-app-version-0.1.12.tgz#08798f6edf870e42dc655a8f1028894428eb72a6"
   integrity sha512-P+0d9+h9HasanKuMd8tcEpuJJlsVmClie3Mbq16v3TV/VroDrgYB6Ea8Imkc/WjjMVSBCjWB+pji1LoupWlddA==
 
-cordova-plugin-background-mode-fixes@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/cordova-plugin-background-mode-fixes/-/cordova-plugin-background-mode-fixes-0.7.6.tgz#b98e6cd319ed3495042e20e6e01142474a2bb568"
-  integrity sha512-9BgAaLy/VcIX7FpWzDDgSIYfN7ZF32QL0U8Ell/5LXEKOqbIZTl8+NpUsotqGxMJ0coaBWoqbkBgqh45NR2H3g==
+"cordova-plugin-background-mode@git+https://bitbucket.org/TheBosZ/cordova-plugin-run-in-background.git":
+  version "0.7.3"
+  resolved "git+https://bitbucket.org/TheBosZ/cordova-plugin-run-in-background.git#df990e762f6ad8fb2021c0001f3576bd9b5b8bb7"
 
 cordova-plugin-badge@^0.8.8:
   version "0.8.8"


### PR DESCRIPTION
- Fixes storage incompatibilities with Android 11
- Android 11 has new storage changes that is incompatible with apps that target Android 10

```
Apps that run on Android 11 but target Android 10 (API level 29) can still request the requestLegacyExternalStorage attribute. This flag allows apps to temporarily opt out of the changes associated with scoped storage, such as granting access to different directories and different types of media files.
```

- Update `cordova-plugin-background-mode` since this doesn't for for newer Android versions
- Add remote config fetch timeout of 10s
- Update subject endpoint methods to force replace fcm token in the app server if it already exists
- Move notifications initialisations (including Firebase initialisations) to the splash service/splash page (custom splash page) from the app component (ionic splash screen)