### PR TITLE
General fixes

### DIFF
--- a/src/app/core/services/config/questionnaire.service.ts
+++ b/src/app/core/services/config/questionnaire.service.ts
@@ -40,14 +40,13 @@ export class QuestionnaireService {
     // NOTE: Update assessment list from protocol
     return Promise.all(
       this.util.deepCopy(assessments).map(a => {
-        const type = this.getAssessmentTypeFromAssessment(a)
         return this.pullDefinitionForSingleQuestionnaire(a)
-          .then(res =>
-            this.addToAssessments(type, Object.assign(res, { type }))
+          .then(assessment =>
+            this.addToAssessments(assessment.type, assessment)
           )
           .catch(e => {
             throw this.logger.error(
-              'Failed to update ' + type + ' assessments',
+              'Failed to update ' + a.name + ' assessment',
               e
             )
           })
@@ -64,6 +63,9 @@ export class QuestionnaireService {
     })
     const language = this.localization.getLanguage().value
     let uri = this.formatQuestionnaireUri(assessment.questionnaire, language)
+    assessment.type = assessment.type
+      ? assessment.type
+      : this.getAssessmentTypeFromAssessment(assessment)
     return this.githubClient
       .getContent(uri)
       .catch(e => {

--- a/src/app/core/services/notifications/message-handler.service.ts
+++ b/src/app/core/services/notifications/message-handler.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core'
 import { FirebaseX } from '@ionic-native/firebase-x/ngx'
+import { Subscription } from 'rxjs'
 
 import { UsageEventType } from '../../../shared/enums/events'
 import { Assessment, AssessmentType } from '../../../shared/models/assessment'
@@ -12,6 +13,8 @@ import { UsageService } from '../usage/usage.service'
 
 @Injectable()
 export class MessageHandlerService {
+  messageListener: Subscription = new Subscription()
+
   constructor(
     public firebase: FirebaseX,
     public logger: LogService,
@@ -20,9 +23,13 @@ export class MessageHandlerService {
     public usage: UsageService,
     public appConfig: AppConfigService
   ) {
-    this.firebase
+    this.messageListener = this.firebase
       .onMessageReceived()
       .subscribe(data => this.onMessageReceived(new Map(Object.entries(data))))
+  }
+
+  ngOnDestroy() {
+    this.messageListener.unsubscribe()
   }
 
   onMessageReceived(data: Map<string, string>) {

--- a/src/app/pages/questions/components/question/question.component.ts
+++ b/src/app/pages/questions/components/question/question.component.ts
@@ -67,8 +67,11 @@ export class QuestionComponent implements OnInit, OnChanges {
   // Input set where height is set to auto
   AUTO_HEIGHT_INPUT_SET: Set<QuestionType> = new Set([
     QuestionType.radio,
+    QuestionType.checkbox,
     QuestionType.yesno,
-    QuestionType.slider
+    QuestionType.slider,
+    QuestionType.range,
+    QuestionType.text
   ])
 
   SCROLLBAR_VISIBLE_SET: Set<QuestionType> = new Set([
@@ -187,13 +190,16 @@ export class QuestionComponent implements OnInit, OnChanges {
   }
 
   onScroll(event) {
-    if (
-      event &&
-      event.target.scrollTop >=
-        (event.target.scrollHeight - event.target.clientHeight) * 0.1
-    ) {
-      this.showScrollButton = false
-    } else this.showScrollButton = true
+    // This will hide/show the scroll arrow depending on the user's scroll event
+    if (this.showScrollButton) {
+      if (
+        event &&
+        event.target.scrollTop >=
+          (event.target.scrollHeight - event.target.clientHeight) * 0.1
+      ) {
+        this.showScrollButton = false
+      } else this.showScrollButton = true
+    }
   }
 
   scrollDown() {


### PR DESCRIPTION
- Pull assessment type for individual questionnaires instead of pulling it at the end (previously, individually added questionnaires' `assessmentType` was null because of this)
- Unsubscribe Firebase message listener when messageHandler is destroyed (to prevent memory leaks)
- Fix scrollDown arrow (to see more) showing incorrectly 