### PR TITLE
Fix publishing script and targetSdk

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -21,6 +21,7 @@
         <allow-intent href="market:*" />
         <preference name="AndroidLaunchMode" value="singleTop" />
         <preference name="AndroidXEnabled" value="true" />
+        <preference name="android-targetSdkVersion" value="30" />
         <icon density="ldpi" src="resources/android/icon/drawable-ldpi-icon.png" />
         <icon density="mdpi" src="resources/android/icon/drawable-mdpi-icon.png" />
         <icon density="hdpi" src="resources/android/icon/drawable-hdpi-icon.png" />

--- a/publishing_script.sh
+++ b/publishing_script.sh
@@ -1,5 +1,6 @@
 ionic cordova build --release android
 
-jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ~/Downloads/radar-armt-release-key.keystore platforms/android/app/build/outputs/apk/release/app-release-unsigned.apk alias_name
+~/Library/Android/sdk/build-tools/28.0.3/zipalign -v 4 platforms/android/app/build/outputs/apk/release/app-release-unsigned.apk ~/Downloads/radar-armt-app-zipaligned.apk
 
- ~/Library/Android/sdk/build-tools/28.0.3/zipalign -v 4 platforms/android/app/build/outputs/apk/release/app-release-unsigned.apk ~/Downloads/radar-armt-app-$1.apk
+~/Library/Android/sdk/build-tools/28.0.3/apksigner sign -v --out ~/Downloads/radar-armt-app-$1.apk --ks ~/Downloads/radar-armt-release-key.keystore --ks-key-alias alias_name ~/Downloads/radar-armt-app-zipaligned.apk
+


### PR DESCRIPTION
- Temporarily set `targetSdk` to `30` for Google play publishing
- Fix publishing script to use new `apkSigner`