### PR TITLE
Fix formatting of questionnaire repo uri

### DIFF
--- a/src/app/core/services/config/questionnaire.service.ts
+++ b/src/app/core/services/config/questionnaire.service.ts
@@ -87,17 +87,22 @@ export class QuestionnaireService {
     const organization = urlParts[1],
       repo = urlParts[2],
       branch = urlParts[3],
-      directory = urlParts[4] + '/' + questionnaireName
+      directory = urlParts.slice(4).join('/')
     const suffix = lang.length ? `_${lang}` : ''
     const fileName =
       questionnaireName + metadata.type + suffix + metadata.format
-    return urljoin(
-      GIT_API_URI,
-      organization,
-      repo,
-      'contents',
-      directory,
-      fileName
+    return (
+      urljoin(
+        GIT_API_URI,
+        organization,
+        repo,
+        'contents',
+        directory,
+        questionnaireName,
+        fileName
+      ) +
+      '?ref=' +
+      branch
     )
   }
 


### PR DESCRIPTION
- The `formatQuestionnaireUri()` method converts the repo url in the protocol.json file into the correct Github API endpoint.
- Previously, it assumed that all the questionnaires will be located in the `questionnaire` directory. This change allows the questionnaires to be inside subdirectories as well.
- This also takes the `branch` value into account (previously only ignored it and used the default branch)