### PR TITLE
Fix refTimestamp prev config

### DIFF
--- a/src/app/core/services/schedule/schedule-generator.service.ts
+++ b/src/app/core/services/schedule/schedule-generator.service.ts
@@ -229,10 +229,11 @@ export class ScheduleGeneratorService {
       }
     } else if (refTimestamp) {
       // Keeps support for previous configuration
-      return this.localization
-        .moment(refTimestamp, this.REFERENCE_TIMESTAMP_FORMAT)
-        .toDate()
-        .getTime()
+      return setDateTimeToMidnightEpoch(
+        this.localization
+          .moment(refTimestamp, this.REFERENCE_TIMESTAMP_FORMAT)
+          .toDate()
+      )
     } else return defaultRefTimestamp
   }
 


### PR DESCRIPTION
- Keep previous refTimestamp configuration the same for backwards compatibility (previously refTimestamp was set to midnight, which was removed in another PR; this PR restores that behaviour)