### PR TITLE
Add new date-input type

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@ionic-native/web-intent": "^5.28.0",
     "@ionic/angular": "^4.0.0-beta.6",
     "@ionic/storage": "2.2.0",
+    "@logisticinfotech/ionic4-datepicker": "^1.4.4",
     "angular-svg-round-progressbar": "^3.0.1",
     "autoprefixer": "^9.8.6",
     "base64-js": "^1.5.1",

--- a/src/app/pages/questions/components/question/question.module.ts
+++ b/src/app/pages/questions/components/question/question.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { IonicModule } from '@ionic/angular'
 import { Ng2FittextModule } from 'ng2-fittext'
+import { Ionic4DatepickerModule } from '@logisticinfotech/ionic4-datepicker'
 
 import { PipesModule } from '../../../../shared/pipes/pipes.module'
 import { WheelSelectorComponent } from '../wheel-selector/wheel-selector.component'
@@ -18,6 +19,7 @@ import { RangeInputComponent } from './range-input/range-input.component'
 import { SliderInputComponent } from './slider-input/slider-input.component'
 import { TextInputComponent } from './text-input/text-input.component'
 import { TimedTestComponent } from './timed-test/timed-test.component'
+import { DateInputComponent } from './date-input/date-input.component'
 
 const COMPONENTS = [
   QuestionComponent,
@@ -32,7 +34,8 @@ const COMPONENTS = [
   TextInputComponent,
   WheelSelectorComponent,
   DescriptiveInputComponent,
-  MatrixRadioInputComponent
+  MatrixRadioInputComponent,
+  DateInputComponent
 ]
 
 @NgModule({
@@ -41,6 +44,7 @@ const COMPONENTS = [
     CommonModule,
     PipesModule,
     FormsModule,
+    Ionic4DatepickerModule,
     IonicModule.forRoot()
   ],
   declarations: COMPONENTS,

--- a/src/app/pages/questions/components/question/question.module.ts
+++ b/src/app/pages/questions/components/question/question.module.ts
@@ -19,7 +19,6 @@ import { RangeInputComponent } from './range-input/range-input.component'
 import { SliderInputComponent } from './slider-input/slider-input.component'
 import { TextInputComponent } from './text-input/text-input.component'
 import { TimedTestComponent } from './timed-test/timed-test.component'
-import { DateInputComponent } from './date-input/date-input.component'
 
 const COMPONENTS = [
   QuestionComponent,
@@ -34,8 +33,7 @@ const COMPONENTS = [
   TextInputComponent,
   WheelSelectorComponent,
   DescriptiveInputComponent,
-  MatrixRadioInputComponent,
-  DateInputComponent
+  MatrixRadioInputComponent
 ]
 
 @NgModule({

--- a/src/app/pages/questions/components/question/text-input/text-input.component.html
+++ b/src/app/pages/questions/components/question/text-input/text-input.component.html
@@ -1,10 +1,8 @@
 <ng-container *ngIf="showDatePicker && currentlyShown">
-  <wheel-selector
-    [values]="datePickerValues"
-    [selection]="defaultDatePickerValue"
-    [labels]="labels"
-    (onSelect)="emitAnswer($event)"
-  ></wheel-selector>
+  <ion-item button (click)="openDatePicker()">
+    <ion-input [(ngModel)]="selectedDate"> </ion-input>
+    <ion-icon name="calendar" slot="end"></ion-icon>
+  </ion-item>
 </ng-container>
 
 <ng-container *ngIf="showTimePicker && currentlyShown">

--- a/src/app/pages/questions/components/question/text-input/text-input.component.scss
+++ b/src/app/pages/questions/components/question/text-input/text-input.component.scss
@@ -5,3 +5,9 @@
 ion-item {
   margin-bottom: 8px !important;
 }
+
+
+ion-input{
+  --background: white;
+  color: var(--ion-color-primary);
+}

--- a/src/app/pages/questions/components/question/text-input/text-input.component.ts
+++ b/src/app/pages/questions/components/question/text-input/text-input.component.ts
@@ -6,6 +6,9 @@ import {
   Output,
   ViewChild
 } from '@angular/core'
+import { ModalController } from '@ionic/angular'
+import { Ionic4DatepickerModalComponent } from '@logisticinfotech/ionic4-datepicker'
+import * as moment from 'moment'
 
 import { LocalizationService } from '../../../../../core/services/misc/localization.service'
 
@@ -50,7 +53,10 @@ export class TextInputComponent implements OnInit {
 
   value = {}
 
-  constructor(private localization: LocalizationService) {}
+  constructor(
+    private localization: LocalizationService,
+    public modalCtrl: ModalController
+  ) {}
 
   ngOnInit() {
     if (this.type.length) {
@@ -71,6 +77,18 @@ export class TextInputComponent implements OnInit {
   }
 
   initDates() {
+    this.datePickerObj = {
+      dateFormat: 'YYYY-MM-DD',
+      btnProperties: {
+        expand: 'block', // Default 'block'
+        fill: 'outline', // Default 'solid'
+        size: 'small', // Default 'default'
+        disabled: '', // Default false
+        strong: 'true', // Default false
+        color: 'secondary' // Default ''
+      },
+      closeOnSelect: 'true'
+    }
     const moment = this.localization.moment(Date.now())
     const locale = moment.localeData()
     const month = locale.monthsShort()
@@ -111,11 +129,43 @@ export class TextInputComponent implements OnInit {
     return values.map(d => (d < 10 ? '0' + d : d)).map(String)
   }
 
+  datePickerObj: any = {}
+  selectedDate: string = new Date().toLocaleDateString('en-ZA')
+
+  async openDatePicker() {
+    const datePickerModal = await this.modalCtrl.create({
+      component: Ionic4DatepickerModalComponent,
+      cssClass: 'li-ionic4-datePicker',
+      componentProps: {
+        objConfig: this.datePickerObj,
+        selectedDate: this.selectedDate
+      }
+    })
+    await datePickerModal.present()
+
+    datePickerModal.onDidDismiss().then(data => {
+      console.log(data)
+      this.selectedDate = data.data.date
+
+      // set defaultDatepickervalue
+      const split_date = data.data.date.split('-')
+      this.defaultDatePickerValue = {
+        year: split_date[0],
+        month: moment()
+          .month(parseInt(split_date[1]) - 1)
+          .format('MMM'),
+        day: split_date[2]
+      }
+      this.emitAnswer(this.defaultDatePickerValue)
+    })
+  }
+
   emitAnswer(value) {
     if (typeof value !== 'string') {
       this.value = Object.assign(this.value, value)
       this.valueChange.emit(JSON.stringify(this.value))
     } else this.valueChange.emit(value)
+    console.log(this.value)
   }
 
   emitTextInputFocus(value) {

--- a/src/app/pages/questions/components/question/text-input/text-input.component.ts
+++ b/src/app/pages/questions/components/question/text-input/text-input.component.ts
@@ -149,21 +149,11 @@ export class TextInputComponent implements OnInit {
       this.selectedDate = data.data.date
 
       // transfer local date format all to US format to easily parse the data
-      const split_date = moment(
-        data.data.date,
-        moment.localeData().longDateFormat('L')
-      )
-        .format('YYYY-MM-DD')
-        .split('-')
-
-      // ex: split_date will be "2022-05-10"
-      // set defaultDatepickervalue
+      const date = moment(data.data.date)
       this.defaultDatePickerValue = {
-        year: split_date[0],
-        month: moment()
-          .month(parseInt(split_date[1]) - 1)
-          .format('MMM'),
-        day: split_date[2]
+        year: date.format('YYYY'),
+        month: date.format('M'),
+        day: date.format('D')
       }
       this.emitAnswer(this.defaultDatePickerValue)
     })

--- a/src/app/pages/questions/components/question/text-input/text-input.component.ts
+++ b/src/app/pages/questions/components/question/text-input/text-input.component.ts
@@ -77,8 +77,12 @@ export class TextInputComponent implements OnInit {
   }
 
   initDates() {
+    const moment = this.localization.moment(Date.now())
+    const locale = moment.localeData()
+    const formatL = locale.longDateFormat('L')
     this.datePickerObj = {
-      dateFormat: 'YYYY-MM-DD',
+      // User the user's locale format as output format
+      dateFormat: formatL,
       btnProperties: {
         expand: 'block', // Default 'block'
         fill: 'outline', // Default 'solid'
@@ -89,8 +93,6 @@ export class TextInputComponent implements OnInit {
       },
       closeOnSelect: 'true'
     }
-    const moment = this.localization.moment(Date.now())
-    const locale = moment.localeData()
     const month = locale.monthsShort()
     const day = this.addLeadingZero(Array.from(Array(32).keys()).slice(1, 32))
     const year = Array.from(Array(31).keys()).map(d => String(d + 2000))
@@ -130,7 +132,7 @@ export class TextInputComponent implements OnInit {
   }
 
   datePickerObj: any = {}
-  selectedDate: string = new Date().toLocaleDateString('en-ZA')
+  selectedDate: string = new Date().toLocaleDateString()
 
   async openDatePicker() {
     const datePickerModal = await this.modalCtrl.create({
@@ -146,8 +148,16 @@ export class TextInputComponent implements OnInit {
     datePickerModal.onDidDismiss().then(data => {
       this.selectedDate = data.data.date
 
+      // transfer local date format all to US format to easily parse the data
+      const split_date = moment(
+        data.data.date,
+        moment.localeData().longDateFormat('L')
+      )
+        .format('YYYY-MM-DD')
+        .split('-')
+
+      // ex: split_date will be "2022-05-10"
       // set defaultDatepickervalue
-      const split_date = data.data.date.split('-')
       this.defaultDatePickerValue = {
         year: split_date[0],
         month: moment()

--- a/src/app/pages/questions/components/question/text-input/text-input.component.ts
+++ b/src/app/pages/questions/components/question/text-input/text-input.component.ts
@@ -144,7 +144,6 @@ export class TextInputComponent implements OnInit {
     await datePickerModal.present()
 
     datePickerModal.onDidDismiss().then(data => {
-      console.log(data)
       this.selectedDate = data.data.date
 
       // set defaultDatepickervalue
@@ -165,7 +164,6 @@ export class TextInputComponent implements OnInit {
       this.value = Object.assign(this.value, value)
       this.valueChange.emit(JSON.stringify(this.value))
     } else this.valueChange.emit(value)
-    console.log(this.value)
   }
 
   emitTextInputFocus(value) {

--- a/src/global.scss
+++ b/src/global.scss
@@ -143,3 +143,41 @@ p {
   padding: 4px;
   border-radius: 8px !important;
 }
+
+
+.li-ionic4-datePicker {
+  .modal-wrapper {
+    height:440px;
+    max-height: 100%;
+    width: 312px;
+    ion-button {
+        --ion-color-primary: white;
+        --border-radious: 5px;
+        --border-color: none;
+        --border-width: 0px !important;
+    }
+    ion-footer{
+      ion-button{
+        --border-width: 2px;
+        --ion-color-primary: var(--ion-color-primary);
+      }
+    }
+
+    .dp-month-year-scroll-container {
+      ion-item {
+          background-color: var(--ion-color-secondary)!important;
+          ion-label {
+              padding:5px;
+              color: white;
+              background-color: var(--ion-color-secondary)!important;
+          }
+          ion-label.dp-selected {
+              color: var(--ion-color-primary);
+              font-size: 20px;
+              font-weight: 500;
+          }
+      }
+    }
+  }
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,6 +646,13 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@logisticinfotech/ionic4-datepicker@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@logisticinfotech/ionic4-datepicker/-/ionic4-datepicker-1.4.4.tgz#ee30b4def3ee5d2ec88df1c0e68c149841eb0b98"
+  integrity sha512-2L22qs3B4kc2a6Dmjv/P3A/MS4ChbAjV+6umfOX3Pt/i3+P7mMHhGDWgFMZVrL14na7uoHewkY1v0CBvC2MW1w==
+  dependencies:
+    tslib "^1.9.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz"


### PR DESCRIPTION
## Problem

Fixes #1392 

## Technical details 

- Utilize https://github.com/logisticinfotech/ionic4-datepicker as date-input type package.
- Replace the `wheel-selector` into `ion-input`  in original `text-input` question type.

## Result 

- Here are some screenshots regarding to the new date-input type.
<img width="327" alt="截圖 2022-05-17 下午3 52 31" src="https://user-images.githubusercontent.com/61721490/168758910-da54bccb-6eb9-46c1-91e5-cce6290f51c7.png">
<img width="324" alt="截圖 2022-05-17 下午3 52 51" src="https://user-images.githubusercontent.com/61721490/168758979-87e436df-0628-4e74-997f-dc70e015278e.png">
<img width="319" alt="截圖 2022-05-17 下午3 53 00" src="https://user-images.githubusercontent.com/61721490/168759007-74599aeb-024c-4abf-92b4-55b1ebac4064.png">

