### PR TITLE
Disable 'next' button when audio recording ongoing

### DIFF
--- a/src/app/pages/questions/components/question/audio-input/audio-input.component.ts
+++ b/src/app/pages/questions/components/question/audio-input/audio-input.component.ts
@@ -27,6 +27,8 @@ import { AudioRecordService } from '../../../services/audio-record.service'
 export class AudioInputComponent implements OnDestroy, OnInit {
   @Output()
   valueChange: EventEmitter<any> = new EventEmitter<any>()
+  @Output()
+  onRecordStart: EventEmitter<any> = new EventEmitter<any>()
   @Input()
   text: string
   @Input()
@@ -77,6 +79,7 @@ export class AudioInputComponent implements OnDestroy, OnInit {
         this.startRecording().catch(e => this.showTaskInterruptedAlert())
     } else {
       this.stopRecording()
+      this.onRecordStart.emit(false)
       if (this.recordAttempts == DefaultMaxAudioAttemptsAllowed)
         this.finishRecording().catch(e => this.showTaskInterruptedAlert())
       else this.showAfterAttemptAlert()
@@ -95,6 +98,7 @@ export class AudioInputComponent implements OnDestroy, OnInit {
       this.permissionUtil.getRecordAudio_Permission(),
       this.permissionUtil.getWriteExternalStorage_permission()
     ]).then(res => {
+      this.onRecordStart.emit(true)
       this.usage.sendGeneralEvent(UsageEventType.RECORDING_STARTED, true)
       return res[0] && res[1]
         ? this.audioRecordService.startAudioRecording()

--- a/src/app/pages/questions/components/question/question.component.html
+++ b/src/app/pages/questions/components/question/question.component.html
@@ -103,6 +103,7 @@
           [text]="question.field_label"
           [currentlyShown]="currentlyShown"
           (valueChange)="emitAnswer($event)"
+          (onRecordStart)="onAudioRecordStart($event)"
         >
         </audio-input>
 

--- a/src/app/pages/questions/components/question/question.component.ts
+++ b/src/app/pages/questions/components/question/question.component.ts
@@ -40,7 +40,7 @@ export class QuestionComponent implements OnInit, OnChanges {
   @Output()
   answer: EventEmitter<Answer> = new EventEmitter<Answer>()
   @Output()
-  autoNext: EventEmitter<Answer> = new EventEmitter<Answer>()
+  nextAction: EventEmitter<any> = new EventEmitter<any>()
 
   value: any
   currentlyShown = false
@@ -130,7 +130,8 @@ export class QuestionComponent implements OnInit, OnChanges {
         value: this.value,
         type: this.question.field_type
       })
-      if (this.question.isAutoNext) this.autoNext.emit()
+      if (this.question.isAutoNext) this.nextAction.emit('auto')
+      else this.nextAction.emit('enable')
     }
   }
 
@@ -141,12 +142,14 @@ export class QuestionComponent implements OnInit, OnChanges {
     ) {
       const min = this.question.select_choices_or_calculations[0].code
       const minLabel = this.question.select_choices_or_calculations[0].label
-      const max = this.question.select_choices_or_calculations[
-        this.question.select_choices_or_calculations.length - 1
-      ].code
-      const maxLabel = this.question.select_choices_or_calculations[
-        this.question.select_choices_or_calculations.length - 1
-      ].label
+      const max =
+        this.question.select_choices_or_calculations[
+          this.question.select_choices_or_calculations.length - 1
+        ].code
+      const maxLabel =
+        this.question.select_choices_or_calculations[
+          this.question.select_choices_or_calculations.length - 1
+        ].label
       this.question.range = {
         min: parseInt(min.trim()),
         max: parseInt(max.trim()),
@@ -171,7 +174,7 @@ export class QuestionComponent implements OnInit, OnChanges {
         break
       }
       case KeyboardEventType.ENTER: {
-        this.autoNext.emit()
+        this.nextAction.emit('auto')
         break
       }
       default:
@@ -207,5 +210,10 @@ export class QuestionComponent implements OnInit, OnChanges {
       left: 0,
       behavior: 'smooth'
     })
+  }
+
+  onAudioRecordStart(start) {
+    if (start) this.nextAction.emit('disable')
+    else this.nextAction.emit('enable')
   }
 }

--- a/src/app/pages/questions/containers/questions-page.component.html
+++ b/src/app/pages/questions/containers/questions-page.component.html
@@ -29,7 +29,7 @@
                 [currentIndex]="currentQuestionGroupId"
                 [isSectionHeaderHidden]="j != currentQuestionIndices[0]"
                 (answer)="onAnswer($event)"
-                (autoNext)="nextQuestion()"
+                (nextAction)="nextAction($event)"
               ></question>
             </ng-container>
           </ion-slide>

--- a/src/app/pages/questions/containers/questions-page.component.ts
+++ b/src/app/pages/questions/containers/questions-page.component.ts
@@ -168,10 +168,7 @@ export class QuestionsPageComponent implements OnInit {
   }
 
   onAnswer(event) {
-    if (event.id) {
-      this.questionsService.submitAnswer(event)
-      setTimeout(() => this.updateToolbarButtons(), 100)
-    }
+    if (event.id) this.questionsService.submitAnswer(event)
   }
 
   slideQuestion() {
@@ -197,6 +194,13 @@ export class QuestionsPageComponent implements OnInit {
     )
   }
 
+  nextAction(event) {
+    if (event == 'auto') return this.nextQuestion()
+    if (event == 'enable')
+      return setTimeout(() => this.updateToolbarButtons(), 100)
+    if (event == 'diisable') return (this.isRightButtonDisabled = true)
+  }
+
   nextQuestion() {
     if (this.isRightButtonDisabled) return
 
@@ -217,9 +221,8 @@ export class QuestionsPageComponent implements OnInit {
   previousQuestion() {
     const currentQuestions = this.getCurrentQuestions()
     this.questionOrder.pop()
-    this.currentQuestionGroupId = this.questionOrder[
-      this.questionOrder.length - 1
-    ]
+    this.currentQuestionGroupId =
+      this.questionOrder[this.questionOrder.length - 1]
     this.updateToolbarButtons()
     if (!this.isRightButtonDisabled)
       this.questionsService.deleteLastAnswers(currentQuestions)
@@ -233,9 +236,8 @@ export class QuestionsPageComponent implements OnInit {
     this.isRightButtonDisabled =
       !this.questionsService.isAnyAnswered(currentQs) &&
       !this.questionsService.getIsAnyNextEnabled(currentQs)
-    this.isLeftButtonDisabled = this.questionsService.getIsAnyPreviousEnabled(
-      currentQs
-    )
+    this.isLeftButtonDisabled =
+      this.questionsService.getIsAnyPreviousEnabled(currentQs)
   }
 
   exitQuestionnaire() {


### PR DESCRIPTION
- This disables the 'next' button when an audio recording is ongoing
- Some users are tapping on the 'next' button while the recording is ongoing (without tapping 'Stop'), thus resulting in missing or corrupted files.