### PR TITLE
fix: fix reset button hover styling

### DIFF
--- a/src/app/pages/settings/containers/settings-page.component.scss
+++ b/src/app/pages/settings/containers/settings-page.component.scss
@@ -61,7 +61,9 @@ ion-back-button {
 }
 
 .bt--full:active {
-  background-color: var(--cl-primary-80);
+  // background-color: var(--cl-primary-80);
+  background-color: var(--cl-danger-40);
+  border-radius: 56px !important;
 }
 
 .info-value {

--- a/src/app/pages/settings/containers/settings-page.component.scss
+++ b/src/app/pages/settings/containers/settings-page.component.scss
@@ -61,7 +61,6 @@ ion-back-button {
 }
 
 .bt--full:active {
-  // background-color: var(--cl-primary-80);
   background-color: var(--cl-danger-40);
   border-radius: 56px !important;
 }


### PR DESCRIPTION
## Problem
- When hover on reset button, the style is primary color and the width is supposed to be rounded, instead it's square.

## Solution
- Add border-radius property and change hover color to danger.

## ScreenShot

https://user-images.githubusercontent.com/61721490/173878316-e5e9805a-5df1-4bd5-90d4-318876978bb6.mov

 