### PR TITLE
[WIP] Implement Health plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@angular/platform-browser-dynamic": "~7.2.13",
     "@angular/router": "~7.2.13",
     "@auth0/angular-jwt": "^4.2.0",
+    "@awesome-cordova-plugins/health": "^5.43.0",
     "@awesome-cordova-plugins/keyboard": "^5.39.0",
     "@ionic-native/android-permissions": "^5.26.0",
     "@ionic-native/app-version": "^5.28.0",
@@ -145,6 +146,7 @@
     "cordova-ios": "5.1.1",
     "cordova-plugin-background-mode": "https://bitbucket.org/TheBosZ/cordova-plugin-run-in-background",
     "cordova-plugin-firebasex": "git+https://github.com/mpgxvii/cordova-plugin-firebasex.git",
+    "cordova-plugin-health": "^2.0.3",
     "cordova-plugin-ionic-webview": "^4.2.1",
     "cordova-plugin-network-information": "git+https://github.com/apache/cordova-plugin-network-information.git",
     "cordova-sqlite-storage": "^6.0.0",
@@ -256,7 +258,11 @@
       "cordova-plugin-ionic-webview": {
         "ANDROID_SUPPORT_ANNOTATIONS_VERSION": "27.+"
       },
-      "cordova-plugin-background-mode": {}
+      "cordova-plugin-background-mode": {},
+      "cordova-plugin-health": {
+        "HEALTH_READ_PERMISSION": "App needs read access",
+        "HEALTH_WRITE_PERMISSION": "App needs write access"
+      }
     }
   },
   "ionic_enable_lint": false

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@angular/platform-browser-dynamic": "~7.2.13",
     "@angular/router": "~7.2.13",
     "@auth0/angular-jwt": "^4.2.0",
+    "@awesome-cordova-plugins/core": "^5.43.0",
     "@awesome-cordova-plugins/health": "^5.43.0",
     "@awesome-cordova-plugins/keyboard": "^5.39.0",
     "@ionic-native/android-permissions": "^5.26.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -63,6 +63,7 @@ import { TranslatePipe } from './shared/pipes/translate/translate'
 import { AndroidPermissionUtility } from './shared/utilities/android-permission'
 import { jwtOptionsFactory } from './shared/utilities/jwtOptionsFactory'
 import { Utility } from './shared/utilities/util'
+import { Health } from '@awesome-cordova-plugins/health/ngx'
 
 @NgModule({
   imports: [
@@ -94,6 +95,7 @@ import { Utility } from './shared/utilities/util'
   bootstrap: [AppComponent],
   entryComponents: [AppComponent],
   providers: [
+    Health,
     Device,
     StatusBar,
     SplashScreen,

--- a/src/app/pages/questions/components/question/health-input/health-input.component.html
+++ b/src/app/pages/questions/components/question/health-input/health-input.component.html
@@ -1,0 +1,3 @@
+<p>
+  health-input works!
+</p>

--- a/src/app/pages/questions/components/question/health-input/health-input.component.ts
+++ b/src/app/pages/questions/components/question/health-input/health-input.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit, Output, Input, EventEmitter } from '@angular/core'
+
+@Component({
+  selector: 'health-input',
+  templateUrl: 'health-input.component.html',
+  styleUrls: ['health-input.component.scss']
+})
+export class HealthInputComponent implements OnInit {
+  @Output()
+  valueChange: EventEmitter<number> = new EventEmitter<number>()
+
+  @Input()
+  responses: Response[]
+  constructor() {}
+
+  ngOnInit() {}
+
+  onInputChange(event) {
+    this.valueChange.emit(event)
+  }
+}

--- a/src/app/pages/questions/components/question/question.module.ts
+++ b/src/app/pages/questions/components/question/question.module.ts
@@ -19,6 +19,7 @@ import { RangeInputComponent } from './range-input/range-input.component'
 import { SliderInputComponent } from './slider-input/slider-input.component'
 import { TextInputComponent } from './text-input/text-input.component'
 import { TimedTestComponent } from './timed-test/timed-test.component'
+import { HealthInputComponent } from './health-input/health-input.component'
 
 const COMPONENTS = [
   QuestionComponent,
@@ -33,7 +34,8 @@ const COMPONENTS = [
   TextInputComponent,
   WheelSelectorComponent,
   DescriptiveInputComponent,
-  MatrixRadioInputComponent
+  MatrixRadioInputComponent,
+  HealthInputComponent
 ]
 
 @NgModule({

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,6 +229,20 @@
   dependencies:
     url "^0.11.0"
 
+"@awesome-cordova-plugins/core@^5.43.0":
+  version "5.43.0"
+  resolved "https://registry.yarnpkg.com/@awesome-cordova-plugins/core/-/core-5.43.0.tgz#3878c474df0c693b99e8da8dc509260d6bd55b2a"
+  integrity sha512-DDLzEYtP6fDqyVORwuzXH64VFYTcW5qoaXAvghWtc5O+wciqeX1hFO7WY7l+1Ytkf6J4IbyMhrsOgZb3bC1eMQ==
+  dependencies:
+    "@types/cordova" latest
+
+"@awesome-cordova-plugins/health@^5.43.0":
+  version "5.43.0"
+  resolved "https://registry.yarnpkg.com/@awesome-cordova-plugins/health/-/health-5.43.0.tgz#45026bb7fa34bdc2cedd7c45e062968fb897f890"
+  integrity sha512-JTrlA9zCS4DOxE0IgZHZnhHtAefgXPdEdwkuU7FIvq47vzjK30hO10E+A4gVLmbMivoJKDZ1xz4PB3vGHJVLZg==
+  dependencies:
+    "@types/cordova" latest
+
 "@awesome-cordova-plugins/keyboard@^5.39.0":
   version "5.39.0"
   resolved "https://registry.npmjs.org/@awesome-cordova-plugins/keyboard/-/keyboard-5.39.0.tgz"
@@ -3014,6 +3028,11 @@ cordova-plugin-globalization@^1.11.0:
   version "1.11.0"
   resolved "https://registry.npmjs.org/cordova-plugin-globalization/-/cordova-plugin-globalization-1.11.0.tgz"
   integrity sha1-6sMVgQAphJOvowvolA5pj2HvvP4=
+
+cordova-plugin-health@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/cordova-plugin-health/-/cordova-plugin-health-2.0.3.tgz#eed86ce278b60e45e1dcc3abc94f1fd8e02350ce"
+  integrity sha512-gy6BNjO86mgdwTrYerCmttvKVRP/zPgyG0h8pBSjbylPZOtbyGtMmmjjhod+srud3YZlqkwFc7vA6fsdpJXGZQ==
 
 cordova-plugin-insomnia@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
# Implement the health plugin into the questionnaire APP

## Solution 

### General idea is when user start the questionnaire means they agree to share their data with our app
1. Collect data like a normal questionnaire 
2. The questionnaire will contain `info-screen` type and newly created `health-input` type, which `info-screen` will tell the user we will be collecting the user's data from Apple Health kit APP and if you agree you can continue with the questionnaire.
3. In the health-input type we will automatically ( first time will trigger Apple Health kit to ask for user's permission) import the data and show it to user( or not show), and user can press the next button and finish the questionnaire.


## Discussion 
- What are the overall data types we need ?
- How often do we want to collect the user's data ( Define in the  questionnaire ? )  ? 
- What's the time frame gonna be when we collect the data ?

## Progress 
- [x] Install Health required plugin and package
- [x] Create a new input type call `health-input`
- [ ] Import the Health data into the `health-input`
- [ ] export the Health data to the database 

## Error 

