### PR TITLE
Ensure that FCM token gets propagated when it is updated

### DIFF
--- a/src/app/core/services/notifications/fcm-rest-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-rest-notification.service.ts
@@ -68,8 +68,8 @@ export class FcmRestNotificationService extends FcmNotificationService {
   }
 
   init() {
-    super.init()
-    return this.appServerService.init()
+    return super.init()
+      .then(() => this.appServerService.init())
   }
 
   onAppOpen() {

--- a/src/app/core/services/storage/storage.service.ts
+++ b/src/app/core/services/storage/storage.service.ts
@@ -4,7 +4,7 @@ import { Observable, Subject, throwError as observableThrowError } from 'rxjs'
 
 import { StorageKeys } from '../../../shared/enums/storage'
 import { LogService } from '../misc/log.service'
-import { filter, map, startWith } from "rxjs/operators";
+import { filter, startWith, switchMap } from "rxjs/operators";
 
 @Injectable()
 export class StorageService {
@@ -59,7 +59,7 @@ export class StorageService {
     return this.keyUpdates.pipe(
       startWith(key),
       filter(k => k === key || k === null),
-      map(k => this.global[k.toString()]),
+      switchMap(k => this.get(k)),
     );
   }
 

--- a/src/app/core/services/storage/storage.service.ts
+++ b/src/app/core/services/storage/storage.service.ts
@@ -1,18 +1,21 @@
 import { Injectable } from '@angular/core'
 import { Storage } from '@ionic/storage'
-import { throwError as observableThrowError } from 'rxjs'
+import { Observable, Subject, throwError as observableThrowError } from 'rxjs'
 
 import { StorageKeys } from '../../../shared/enums/storage'
 import { LogService } from '../misc/log.service'
+import { filter, map, startWith } from "rxjs/operators";
 
 @Injectable()
 export class StorageService {
   global: { [key: string]: any } = {}
+  private readonly keyUpdates: Subject<StorageKeys | null>
 
   constructor(private storage: Storage, private logger: LogService) {
     this.prepare().then(() =>
       this.logger.log('Global configuration', this.global)
     )
+    this.keyUpdates = new Subject<StorageKeys | null>();
   }
 
   getStorageState() {
@@ -23,15 +26,23 @@ export class StorageService {
     const k = key.toString()
     this.global[k] = value
     return this.storage.set(k, value)
+      .then(res => {
+        this.keyUpdates.next(key);
+        return res;
+      });
   }
 
   push(key: StorageKeys, value: any): Promise<any> {
     if (this.global[key.toString()]) this.global[key.toString()].push(value)
     else this.global[key.toString()] = [value]
     return this.storage.set(key.toString(), this.global[key.toString()])
+      .then(res => {
+        this.keyUpdates.next(key);
+        return res;
+      });
   }
 
-  get(key: StorageKeys) {
+  get(key: StorageKeys): Promise<any> {
     const k = key.toString()
     const local = this.global[k]
     if (local !== undefined) {
@@ -44,12 +55,21 @@ export class StorageService {
     }
   }
 
+  observe(key: StorageKeys): Observable<any> {
+    return this.keyUpdates.pipe(
+      startWith(key),
+      filter(k => k === key || k === null),
+      map(k => this.global[k.toString()]),
+    );
+  }
+
   remove(key: StorageKeys) {
     const k = key.toString()
     return this.storage
       .remove(k)
       .then(res => {
         this.global[k] = null
+        this.keyUpdates.next(key);
         return res
       })
       .catch(error => this.handleError(error))
@@ -72,6 +92,7 @@ export class StorageService {
   clear() {
     this.global = {}
     return this.storage.clear()
+      .then(() => this.keyUpdates.next(null));
   }
 
   private handleError(error: any) {


### PR DESCRIPTION
This ensures that when the fetching or updating of the FCM token is delayed, the FCM token still gets propagated to the appserver. It uses Observables to fetch the FcmToken from storage. It also uses Promises to wait for the Firebase initialisation in `FcmNotificationService.init` to be complete. It uses subscriptions to ensure that multiple observables are not run simultaneously if `init()` gets called multiple times, for example, after logout/login.

I haven't tested what happens if `FcmNotificationService.unregisterFromNotifications` gets called. Would that also need a call to the underlying app server to ensure no more notifications are attempted for that user? Particularly, I see that Firebase notifications are unsubscribed from within `ConfigService.resetAll`, but it is not re-subscribed again.