### PR TITLE
Ensure that questionnaire Kafka topic exists

### DIFF
--- a/src/app/core/services/kafka/kafka.service.spec.ts
+++ b/src/app/core/services/kafka/kafka.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing'
 
 import {
   FirebaseAnalyticsServiceMock,
-  LogServiceMock,
+  LogServiceMock, RemoteConfigServiceMock,
   SchemaServiceMock,
   StorageServiceMock,
   TokenServiceMock
@@ -14,6 +14,7 @@ import { TokenService } from '../token/token.service'
 import { AnalyticsService } from '../usage/analytics.service'
 import { KafkaService } from './kafka.service'
 import { SchemaService } from './schema.service'
+import { RemoteConfigService } from "../config/remote-config.service";
 
 describe('KafkaService', () => {
   let service
@@ -31,7 +32,8 @@ describe('KafkaService', () => {
         {
           provide: AnalyticsService,
           useClass: FirebaseAnalyticsServiceMock
-        }
+        },
+        { provide: RemoteConfigService, useClass: RemoteConfigServiceMock },
       ]
     })
   )

--- a/src/app/core/services/kafka/kafka.service.ts
+++ b/src/app/core/services/kafka/kafka.service.ts
@@ -15,9 +15,13 @@ import { StorageService } from '../storage/storage.service'
 import { TokenService } from '../token/token.service'
 import { AnalyticsService } from '../usage/analytics.service'
 import { SchemaService } from './schema.service'
+import { RemoteConfigService } from "../config/remote-config.service";
+import { ConfigKeys } from "../../../shared/enums/config";
 
 @Injectable()
 export class KafkaService {
+  private static DEFAULT_TOPIC_CACHE_VALIDITY = 600_000 // 10 minutes
+
   URI_topics: string = '/topics/'
 
   private readonly KAFKA_STORE = {
@@ -27,6 +31,9 @@ export class KafkaService {
   private KAFKA_CLIENT_URL: string
   private BASE_URI: string
   private isCacheSending: boolean
+  private topics: string[] = null
+  private lastTopicFetch: number = 0
+  private TOPIC_CACHE_VALIDITY = KafkaService.DEFAULT_TOPIC_CACHE_VALIDITY
 
   constructor(
     private storage: StorageService,
@@ -34,20 +41,69 @@ export class KafkaService {
     private schema: SchemaService,
     private analytics: AnalyticsService,
     private logger: LogService,
-    private http: HttpClient
+    private http: HttpClient,
+    private remoteConfig: RemoteConfigService,
   ) {
     this.updateURI()
+    this.readTopicCacheValidity();
   }
 
   init() {
-    return this.setCache({})
+    return Promise.all([
+      this.setCache({}),
+      this.updateTopicCacheValidity(),
+      this.fetchTopics(),
+    ]);
   }
 
   updateURI() {
-    this.token.getURI().then(uri => {
+    return this.token.getURI().then(uri => {
       this.BASE_URI = uri
       this.KAFKA_CLIENT_URL = uri + DefaultKafkaURI
     })
+  }
+
+  readTopicCacheValidity() {
+    return this.storage.get(StorageKeys.TOPIC_CACHE_TIMEOUT)
+      .then(timeout => {
+        if (typeof timeout === 'number') {
+          this.TOPIC_CACHE_VALIDITY = timeout
+        }
+      });
+  }
+
+  updateTopicCacheValidity() {
+    return this.remoteConfig.read()
+      .then(config => config.getOrDefault(ConfigKeys.TOPIC_CACHE_TIMEOUT, this.TOPIC_CACHE_VALIDITY.toString()))
+      .then(timeoutString => {
+        const timeout = parseInt(timeoutString)
+        if (!isNaN(timeout)) {
+          this.TOPIC_CACHE_VALIDITY = Math.max(0, timeout)
+          return this.storage.set(StorageKeys.TOPIC_CACHE_TIMEOUT, this.TOPIC_CACHE_VALIDITY)
+        }
+      })
+  }
+
+  private fetchTopics() {
+    return this.http.get(this.KAFKA_CLIENT_URL + this.URI_topics, {observe: 'body'})
+      .toPromise()
+      .then((topics: string[]) => {
+        this.topics = topics
+        this.lastTopicFetch = Date.now()
+        return topics
+      })
+      .catch(e => {
+        this.logger.error("Failed to fetch Kafka topics", e)
+        return this.topics
+      });
+  }
+
+  getTopics() {
+    if (this.topics !== null || this.lastTopicFetch + this.TOPIC_CACHE_VALIDITY >= Date.now()) {
+      return Promise.resolve(this.topics)
+    } else {
+      return this.fetchTopics();
+    }
   }
 
   prepareKafkaObjectAndSend(type, payload, keepInCache?) {
@@ -83,14 +139,15 @@ export class KafkaService {
     return Promise.all([
       this.getCache(),
       this.getKafkaHeaders(),
-      this.schema.getRadarSpecifications()
+      this.schema.getRadarSpecifications(),
+      this.getTopics(),
     ])
-      .then(([cache, headers, specifications]) => {
+      .then(([cache, headers, specifications, topics]) => {
         const sendPromises = Object.entries(cache)
           .filter(([k]) => k)
           .map(([k, v]: any) => {
             return this.schema
-              .getKafkaTopic(specifications, v.name, v.avsc)
+              .getKafkaTopic(specifications, v.name, v.avsc, topics)
               .then(topic => this.sendToKafka(topic, k, v, headers))
               .catch(e =>
                 this.logger.error('Failed to send data from cache to kafka', e)

--- a/src/app/core/services/kafka/schema.service.ts
+++ b/src/app/core/services/kafka/schema.service.ts
@@ -22,7 +22,6 @@ import { QuestionnaireService } from '../config/questionnaire.service'
 import { RemoteConfigService } from '../config/remote-config.service'
 import { SubjectConfigService } from '../config/subject-config.service'
 import { LogService } from '../misc/log.service'
-import { valid } from "semver";
 
 @Injectable()
 export class SchemaService {

--- a/src/app/core/services/kafka/schema.service.ts
+++ b/src/app/core/services/kafka/schema.service.ts
@@ -22,11 +22,13 @@ import { QuestionnaireService } from '../config/questionnaire.service'
 import { RemoteConfigService } from '../config/remote-config.service'
 import { SubjectConfigService } from '../config/subject-config.service'
 import { LogService } from '../misc/log.service'
+import { valid } from "semver";
 
 @Injectable()
 export class SchemaService {
   URI_schema: string = '/schema/subjects/'
   URI_version: string = '/versions/'
+  GENERAL_TOPIC: string = 'questionnaire_response'
   private schemas: {
     [key: string]: [Promise<SchemaMetadata>, Promise<SchemaMetadata>]
   } = {}
@@ -153,17 +155,34 @@ export class SchemaService {
       })
   }
 
-  getKafkaTopic(specifications: any[] | null, name, avsc): Promise<any> {
-    try {
-      const type = name.toLowerCase()
-      const defaultTopic = `${avsc}_${name}`
-      if (specifications) {
-        const spec = specifications.find(t => t.type.toLowerCase() == type)
-        return Promise.resolve(spec && spec.topic ? spec.topic : defaultTopic)
+  getKafkaTopic(specifications: any[] | null, name, avsc, topics: string[] | null): Promise<any> {
+    const type = name.toLowerCase()
+
+    if (specifications) {
+      const spec = specifications.find(t => t.type.toLowerCase() == type)
+      if (spec && spec.topic && this.topicExists(spec.topic, topics)) {
+        return Promise.resolve(spec.topic)
       }
+    }
+    const questionnaireTopic = `${avsc}_${name}`
+    if (this.topicExists(questionnaireTopic, topics)) {
+      return Promise.resolve(questionnaireTopic)
+    }
+    const defaultTopic = this.GENERAL_TOPIC;
+    if (this.topicExists(defaultTopic, topics)) {
       return Promise.resolve(defaultTopic)
-    } catch (e) {
-      return Promise.reject('Failed to get kafka topic')
+    }
+
+    return Promise.reject(`No suitable topic found on server for questionnaire ${name}`)
+  }
+
+  private topicExists(topic: string, topics: string[] | null) {
+    if (!topics || topics.includes(topic)) {
+      return true
+    } else {
+      this.logger.error(
+        `Cannot send data to specification topic ${topic} because target server does not have it`, null)
+      return false
     }
   }
 

--- a/src/app/shared/enums/config.ts
+++ b/src/app/shared/enums/config.ts
@@ -35,6 +35,10 @@ export class ConfigKeys {
 
   static GITHUB_FETCH_STRATEGY = new ConfigKeys('github_fetch_strategy')
 
+  static TOPIC_CACHE_TIMEOUT = new ConfigKeys(
+    'topic_cache_timeout'
+  )
+
   constructor(public value: string) {}
 
   toString() {

--- a/src/app/shared/enums/storage.ts
+++ b/src/app/shared/enums/storage.ts
@@ -42,6 +42,10 @@ export class StorageKeys {
     'REMOTE_CONFIG_CACHE_TIMEOUT'
   )
 
+  static TOPIC_CACHE_TIMEOUT = new StorageKeys(
+    'TOPIC_CACHE_TIMEOUT'
+  )
+
   static FCM_TOKEN = new StorageKeys('FCM_TOKEN')
   static NOTIFICATION_MESSAGING_TYPE = new StorageKeys(
     'NOTIFICATION_MESSAGING_TYPE'


### PR DESCRIPTION
This adds a query to the RADAR-base Kafka endpoint to query the list of topics before trying to send data. Data will not be attempted to be sent to topics that do not exist. In combination with RADAR-base/RADAR-Schemas#310, it will send questionnaires that do not have a correct topic defined to the general `questionnaire_response` Kafka topic. This topic is intended to receive data from all questionnaires, even if not defined in RADAR-Schemas.

The list of Kafka topics is cached for 10 minutes by default, and it is customisable in remote config with key `topic_cache_timeout`.

Once RADAR-base/radar-output-restructure#528 is also published, the `questionnaire_response` topic can be separated into multiple directories in the output.