### PR TITLE
Add support for NHS/web data input

### DIFF
--- a/src/app/pages/questions/components/question/notes-input/notes-input.component.html
+++ b/src/app/pages/questions/components/question/notes-input/notes-input.component.html
@@ -1,0 +1,12 @@
+<ion-item color="none" class="input">
+  <ion-textarea
+    fill="outline"
+    [autoGrow]="true"
+    placeholder="{{ 'PLACEHOLDER_TEXT_INPUT' | translate }}"
+    [(ngModel)]="textValue"
+    (ionChange)="emitAnswer('')"
+    (ionFocus)="emitKeyboardEvent('focus')"
+    (ionBlur)="emitKeyboardEvent('blur')"
+    (keyup)="emitKeyboardEvent($event.key)"
+  ></ion-textarea>
+</ion-item>

--- a/src/app/pages/questions/components/question/notes-input/notes-input.component.scss
+++ b/src/app/pages/questions/components/question/notes-input/notes-input.component.scss
@@ -1,0 +1,15 @@
+ion-item {
+  margin-bottom: 8px !important;
+}
+
+.input {
+  padding-left: 0;
+  width: 80vw;
+  border-start-end-radius: 20px;
+  border-start-start-radius: 20px;
+  border-bottom: 2px solid white;
+  background-color: var(--cl-primary-10);
+  color: var(--ion-font);
+  font-size: 18px;
+  line-height: 1.35em;
+}

--- a/src/app/pages/questions/components/question/notes-input/notes-input.component.ts
+++ b/src/app/pages/questions/components/question/notes-input/notes-input.component.ts
@@ -1,0 +1,44 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
+import { Keyboard } from '@ionic-native/keyboard/ngx'
+import { ModalController } from '@ionic/angular'
+
+import { LocalizationService } from '../../../../../core/services/misc/localization.service'
+import { KeyboardEventType } from '../../../../../shared/enums/events'
+
+@Component({
+  selector: 'notes-input',
+  templateUrl: 'notes-input.component.html',
+  styleUrls: ['notes-input.component.scss']
+})
+export class NotesInputComponent implements OnInit {
+  @Output()
+  valueChange: EventEmitter<string> = new EventEmitter<string>()
+  @Output()
+  keyboardEvent: EventEmitter<string> = new EventEmitter<string>()
+  @Input()
+  type: string
+  @Input()
+  currentlyShown: boolean
+
+  textValue = ''
+  value = {}
+
+  constructor(
+    private localization: LocalizationService,
+    public modalCtrl: ModalController,
+    private keyboard: Keyboard
+  ) {}
+
+  ngOnInit() {}
+
+  emitAnswer(value) {
+    this.valueChange.emit(this.textValue)
+  }
+
+  emitKeyboardEvent(value) {
+    value = value.toLowerCase()
+    if (value == KeyboardEventType.ENTER) this.keyboard.hide()
+
+    this.keyboardEvent.emit(value)
+  }
+}

--- a/src/app/pages/questions/components/question/question.component.html
+++ b/src/app/pages/questions/components/question/question.component.html
@@ -157,6 +157,8 @@
         [text]="question.field_label"
         (valueChange)="emitAnswer($event)"
         [currentlyShown]="currentlyShown"
+        [url]="webInputUrl"
+        [validator]="webInputValidator"
       >
       </web-input>
 

--- a/src/app/pages/questions/components/question/question.component.html
+++ b/src/app/pages/questions/components/question/question.component.html
@@ -153,12 +153,19 @@
       </matrix-radio-input>
 
       <web-input
-        *ngSwitchCase="'web-input'"
+        *ngSwitchCase="'web'"
         [text]="question.field_label"
         (valueChange)="emitAnswer($event)"
         [currentlyShown]="currentlyShown"
       >
       </web-input>
+
+      <notes-input
+        *ngSwitchCase="'notes'"
+        (valueChange)="emitAnswer($event)"
+        (keyboardEvent)="onKeyboardEvent($event)"
+        [currentlyShown]="currentlyShown"
+      ></notes-input>
     </div>
   </div>
   <div class="arrow-icon" *ngIf="showScrollButton" (click)="scrollDown()">

--- a/src/app/pages/questions/components/question/question.component.html
+++ b/src/app/pages/questions/components/question/question.component.html
@@ -157,8 +157,7 @@
         [text]="question.field_label"
         (valueChange)="emitAnswer($event)"
         [currentlyShown]="currentlyShown"
-        [url]="webInputUrl"
-        [validator]="webInputValidator"
+        [type]="question.field_annotation"
       >
       </web-input>
 

--- a/src/app/pages/questions/components/question/question.component.html
+++ b/src/app/pages/questions/components/question/question.component.html
@@ -151,6 +151,14 @@
         (valueChange)="emitAnswer($event)"
       >
       </matrix-radio-input>
+
+      <web-input
+        *ngSwitchCase="'web-input'"
+        [text]="question.field_label"
+        (valueChange)="emitAnswer($event)"
+        [currentlyShown]="currentlyShown"
+      >
+      </web-input>
     </div>
   </div>
   <div class="arrow-icon" *ngIf="showScrollButton" (click)="scrollDown()">

--- a/src/app/pages/questions/components/question/question.component.ts
+++ b/src/app/pages/questions/components/question/question.component.ts
@@ -13,6 +13,7 @@ import { Keyboard } from '@ionic-native/keyboard/ngx'
 import { Vibration } from '@ionic-native/vibration/ngx'
 import { IonContent } from '@ionic/angular'
 import * as smoothscroll from 'smoothscroll-polyfill'
+import { isValidNHSId } from 'src/app/shared/utilities/form-validators'
 
 import {
   KeyboardEventType,
@@ -84,7 +85,10 @@ export class QuestionComponent implements OnInit, OnChanges {
     QuestionType.audio,
     QuestionType.descriptive
   ])
-  MATRIX_INPUT_SET: Set<QuestionType> = new Set([QuestionType.matrix_radio,QuestionType.health])
+  MATRIX_INPUT_SET: Set<QuestionType> = new Set([
+    QuestionType.matrix_radio,
+    QuestionType.health
+  ])
 
   // Input set where height is set to auto
   AUTO_HEIGHT_INPUT_SET: Set<QuestionType> = new Set([
@@ -101,6 +105,11 @@ export class QuestionComponent implements OnInit, OnChanges {
     QuestionType.radio,
     QuestionType.checkbox
   ])
+
+  NHS_URL = 'https://www.nhs.uk/nhs-services/online-services/find-nhs-number/'
+  NHS_LABEL = 'nhs'
+  webInputUrl = this.NHS_URL
+  webInputValidator = isValidNHSId
 
   constructor(private vibration: Vibration, private dialogs: Dialogs) {
     smoothscroll.polyfill()
@@ -129,6 +138,7 @@ export class QuestionComponent implements OnInit, OnChanges {
 
   ngOnChanges() {
     this.initRange()
+    this.initWebInput()
     if (this.questionIndex === this.currentIndex) {
       this.currentlyShown = true
     } else {
@@ -174,6 +184,13 @@ export class QuestionComponent implements OnInit, OnChanges {
         labelLeft: minLabel.trim(),
         labelRight: maxLabel.trim()
       }
+    }
+  }
+
+  initWebInput() {
+    if (this.question.field_annotation == this.NHS_LABEL) {
+      this.webInputUrl = this.NHS_URL
+      this.webInputValidator = isValidNHSId
     }
   }
 

--- a/src/app/pages/questions/components/question/question.component.ts
+++ b/src/app/pages/questions/components/question/question.component.ts
@@ -9,11 +9,8 @@ import {
   ViewChild
 } from '@angular/core'
 import { Dialogs } from '@ionic-native/dialogs/ngx'
-import { Keyboard } from '@ionic-native/keyboard/ngx'
 import { Vibration } from '@ionic-native/vibration/ngx'
-import { IonContent } from '@ionic/angular'
 import * as smoothscroll from 'smoothscroll-polyfill'
-import { isValidNHSId } from 'src/app/shared/utilities/form-validators'
 
 import {
   KeyboardEventType,
@@ -106,11 +103,6 @@ export class QuestionComponent implements OnInit, OnChanges {
     QuestionType.checkbox
   ])
 
-  NHS_URL = 'https://www.nhs.uk/nhs-services/online-services/find-nhs-number/'
-  NHS_LABEL = 'nhs'
-  webInputUrl = this.NHS_URL
-  webInputValidator = isValidNHSId
-
   constructor(private vibration: Vibration, private dialogs: Dialogs) {
     smoothscroll.polyfill()
     this.value = null
@@ -138,7 +130,6 @@ export class QuestionComponent implements OnInit, OnChanges {
 
   ngOnChanges() {
     this.initRange()
-    this.initWebInput()
     if (this.questionIndex === this.currentIndex) {
       this.currentlyShown = true
     } else {
@@ -184,13 +175,6 @@ export class QuestionComponent implements OnInit, OnChanges {
         labelLeft: minLabel.trim(),
         labelRight: maxLabel.trim()
       }
-    }
-  }
-
-  initWebInput() {
-    if (this.question.field_annotation == this.NHS_LABEL) {
-      this.webInputUrl = this.NHS_URL
-      this.webInputValidator = isValidNHSId
     }
   }
 

--- a/src/app/pages/questions/components/question/question.module.ts
+++ b/src/app/pages/questions/components/question/question.module.ts
@@ -9,6 +9,7 @@ import { WheelSelectorComponent } from '../wheel-selector/wheel-selector.compone
 import { AudioInputComponent } from './audio-input/audio-input.component'
 import { CheckboxInputComponent } from './checkbox-input/checkbox-input.component'
 import { DescriptiveInputComponent } from './descriptive-input/descriptive-input.component'
+import { HealthInputComponent } from './health-input/health-input.component'
 import { InfoScreenComponent } from './info-screen/info-screen.component'
 import { MatrixRadioInputComponent } from './matrix-radio-input/matrix-radio-input.component'
 import { QuestionComponent } from './question.component'
@@ -18,7 +19,7 @@ import { RangeInputComponent } from './range-input/range-input.component'
 import { SliderInputComponent } from './slider-input/slider-input.component'
 import { TextInputComponent } from './text-input/text-input.component'
 import { TimedTestComponent } from './timed-test/timed-test.component'
-import { HealthInputComponent } from './health-input/health-input.component'
+import { WebInputComponent } from './web-input/web-input.component'
 
 const COMPONENTS = [
   QuestionComponent,
@@ -34,7 +35,8 @@ const COMPONENTS = [
   WheelSelectorComponent,
   DescriptiveInputComponent,
   MatrixRadioInputComponent,
-  HealthInputComponent
+  HealthInputComponent,
+  WebInputComponent
 ]
 
 @NgModule({

--- a/src/app/pages/questions/components/question/question.module.ts
+++ b/src/app/pages/questions/components/question/question.module.ts
@@ -12,6 +12,7 @@ import { DescriptiveInputComponent } from './descriptive-input/descriptive-input
 import { HealthInputComponent } from './health-input/health-input.component'
 import { InfoScreenComponent } from './info-screen/info-screen.component'
 import { MatrixRadioInputComponent } from './matrix-radio-input/matrix-radio-input.component'
+import { NotesInputComponent } from './notes-input/notes-input.component'
 import { QuestionComponent } from './question.component'
 import { RadioInputComponent } from './radio-input/radio-input.component'
 import { RangeInfoInputComponent } from './range-info-input/range-info-input.component'
@@ -36,7 +37,8 @@ const COMPONENTS = [
   DescriptiveInputComponent,
   MatrixRadioInputComponent,
   HealthInputComponent,
-  WebInputComponent
+  WebInputComponent,
+  NotesInputComponent
 ]
 
 @NgModule({

--- a/src/app/pages/questions/components/question/web-input/web-input.component.html
+++ b/src/app/pages/questions/components/question/web-input/web-input.component.html
@@ -1,0 +1,25 @@
+<ion-content class="content" #content [scrollY]="true">
+  <div class="items">
+    <ion-item color="none" class="input">
+      <ion-input
+        type="text"
+        enterkeyhint="next"
+        placeholder="Enter NHS number"
+        [(ngModel)]="textValue"
+        (ionChange)="emitAnswer('')"
+        (ionFocus)="emitKeyboardEvent('focus')"
+        (ionBlur)="emitKeyboardEvent('blur')"
+        (keyup)="emitKeyboardEvent($event.key)"
+      ></ion-input>
+    </ion-item>
+    <ion-button
+      ion-button
+      class="bt bt--full policy"
+      round
+      full
+      (click)="openUrl()"
+    >
+      Login to NHS
+    </ion-button>
+  </div>
+</ion-content>

--- a/src/app/pages/questions/components/question/web-input/web-input.component.html
+++ b/src/app/pages/questions/components/question/web-input/web-input.component.html
@@ -1,9 +1,11 @@
 <ion-content class="content" #content [scrollY]="true">
   <div class="items">
+    <ion-label *ngIf="!inputValid">Please enter a valid NHS number.</ion-label>
     <ion-item color="none" class="input">
       <ion-input
         type="text"
         enterkeyhint="next"
+        maxlength="15"
         placeholder="Enter NHS number"
         [(ngModel)]="textValue"
         (ionChange)="emitAnswer('')"

--- a/src/app/pages/questions/components/question/web-input/web-input.component.scss
+++ b/src/app/pages/questions/components/question/web-input/web-input.component.scss
@@ -1,0 +1,63 @@
+.info-card {
+  padding: 16px;
+  height: 92%;
+  -webkit-border-radius: 8px;
+  border-radius: 8px;
+  background-color: var(--cl-primary-20);
+  overflow: scroll;
+}
+
+ion-content {
+  width: 75vw;
+  --background: transparent;
+  mask-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(rgba(0, 0, 0, 1)),
+    to(rgba(0, 0, 0, 0.25))
+  );
+  overflow: scroll;
+}
+
+.items {
+  padding-bottom: 32%;
+  overflow: scroll;
+}
+
+.info-heading {
+  opacity: 0.6;
+}
+
+.info-content {
+  margin-bottom: 48%;
+  overflow: scroll;
+}
+
+.image {
+  margin: auto;
+  width: 104px;
+  height: auto;
+}
+
+.image-container {
+  text-align: center;
+}
+
+.icon {
+  position: relative;
+  float: right;
+  margin: -36px 8px;
+  width: inherit;
+  text-align: right;
+}
+
+ion-icon {
+  color: var(--cl-light-40);
+  font-size: 40px;
+}
+
+ion-button {
+  margin-top: 24px;
+  margin-bottom: 24px;
+}

--- a/src/app/pages/questions/components/question/web-input/web-input.component.scss
+++ b/src/app/pages/questions/components/question/web-input/web-input.component.scss
@@ -7,6 +7,11 @@
   overflow: scroll;
 }
 
+ion-label {
+  margin-left: 4px;
+  font-size: 12px;
+}
+
 ion-content {
   width: 75vw;
   --background: transparent;
@@ -27,11 +32,6 @@ ion-content {
 
 .info-heading {
   opacity: 0.6;
-}
-
-.info-content {
-  margin-bottom: 48%;
-  overflow: scroll;
 }
 
 .image {

--- a/src/app/pages/questions/components/question/web-input/web-input.component.ts
+++ b/src/app/pages/questions/components/question/web-input/web-input.component.ts
@@ -12,8 +12,8 @@ import {
   InAppBrowserOptions
 } from '@awesome-cordova-plugins/in-app-browser/ngx'
 import { Keyboard } from '@ionic-native/keyboard/ngx'
-import { IonContent } from '@ionic/angular'
 import { KeyboardEventType } from 'src/app/shared/enums/events'
+import { isValidNHSId } from 'src/app/shared/utilities/form-validators'
 
 @Component({
   selector: 'web-input',
@@ -31,6 +31,7 @@ export class WebInputComponent implements OnInit {
   currentlyShown: boolean
 
   textValue = ''
+  inputValid = true
   NHS_URL = 'https://www.nhs.uk/nhs-services/online-services/find-nhs-number/'
 
   browserOptions: InAppBrowserOptions = {
@@ -49,7 +50,11 @@ export class WebInputComponent implements OnInit {
   ngOnInit() {}
 
   emitAnswer(value) {
-    this.valueChange.emit(this.textValue)
+    const cleanedValue = value.replace(/\s/g, '')
+    const valid = isValidNHSId(cleanedValue)
+    if (valid) {
+      this.valueChange.emit(this.textValue)
+    } else this.inputValid = false
   }
 
   emitKeyboardEvent(value) {

--- a/src/app/pages/questions/components/question/web-input/web-input.component.ts
+++ b/src/app/pages/questions/components/question/web-input/web-input.component.ts
@@ -1,0 +1,69 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core'
+import {
+  InAppBrowser,
+  InAppBrowserOptions
+} from '@awesome-cordova-plugins/in-app-browser/ngx'
+import { Keyboard } from '@ionic-native/keyboard/ngx'
+import { IonContent } from '@ionic/angular'
+import { KeyboardEventType } from 'src/app/shared/enums/events'
+
+@Component({
+  selector: 'web-input',
+  templateUrl: 'web-input.component.html',
+  styleUrls: ['web-input.component.scss']
+})
+export class WebInputComponent implements OnInit {
+  @Output()
+  valueChange: EventEmitter<string> = new EventEmitter<string>()
+  @Output()
+  keyboardEvent: EventEmitter<string> = new EventEmitter<string>()
+  @Input()
+  text: string
+  @Input()
+  currentlyShown: boolean
+
+  textValue = ''
+  NHS_URL = 'https://www.nhs.uk/nhs-services/online-services/find-nhs-number/'
+
+  browserOptions: InAppBrowserOptions = {
+    location: 'yes',
+    hidenavigationbuttons: 'yes',
+    hideurlbar: 'yes',
+    toolbarcolor: '#6d9aa5',
+    closebuttoncolor: '#ffffff'
+  }
+
+  constructor(
+    private theInAppBrowser: InAppBrowser,
+    private keyboard: Keyboard
+  ) {}
+
+  ngOnInit() {}
+
+  emitAnswer(value) {
+    this.valueChange.emit(this.textValue)
+  }
+
+  emitKeyboardEvent(value) {
+    value = value.toLowerCase()
+    if (value == KeyboardEventType.ENTER) this.keyboard.hide()
+
+    this.keyboardEvent.emit(value)
+  }
+
+  openUrl() {
+    this.openWithInAppBrowser(this.NHS_URL)
+  }
+
+  openWithInAppBrowser(url: string) {
+    this.theInAppBrowser.create(url, '_blank', this.browserOptions)
+  }
+}

--- a/src/app/pages/questions/components/question/web-input/web-input.component.ts
+++ b/src/app/pages/questions/components/question/web-input/web-input.component.ts
@@ -13,6 +13,8 @@ import {
 } from '@awesome-cordova-plugins/in-app-browser/ngx'
 import { Keyboard } from '@ionic-native/keyboard/ngx'
 import { KeyboardEventType } from 'src/app/shared/enums/events'
+import { WebInputType } from 'src/app/shared/models/question'
+import { isValidNHSId } from 'src/app/shared/utilities/form-validators'
 
 @Component({
   selector: 'web-input',
@@ -29,12 +31,13 @@ export class WebInputComponent implements OnInit {
   @Input()
   currentlyShown: boolean
   @Input()
-  url: string
-  @Input()
-  validator
+  type: string
 
+  url: string
+  validator
   textValue = ''
   inputValid = true
+  NHS_URL = 'https://www.nhs.uk/nhs-services/online-services/find-nhs-number/'
 
   browserOptions: InAppBrowserOptions = {
     location: 'yes',
@@ -49,7 +52,10 @@ export class WebInputComponent implements OnInit {
     private keyboard: Keyboard
   ) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+      this.url = this.getWebUrl()
+      this.validator = this.getInputValidator()
+  }
 
   emitAnswer(value) {
     const valid = this.validator(this.textValue)
@@ -72,5 +78,23 @@ export class WebInputComponent implements OnInit {
 
   openWithInAppBrowser(url: string) {
     this.theInAppBrowser.create(url, '_blank', this.browserOptions)
+  }
+
+  getWebUrl() {
+    switch(this.type) {
+      case WebInputType.NHS: 
+        return this.NHS_URL
+      default:
+        return this.NHS_URL
+    }
+  }
+
+  getInputValidator() {
+    switch(this.type) {
+      case WebInputType.NHS: 
+        return isValidNHSId
+      default:
+        return isValidNHSId
+    } 
   }
 }

--- a/src/app/pages/questions/components/question/web-input/web-input.component.ts
+++ b/src/app/pages/questions/components/question/web-input/web-input.component.ts
@@ -13,7 +13,6 @@ import {
 } from '@awesome-cordova-plugins/in-app-browser/ngx'
 import { Keyboard } from '@ionic-native/keyboard/ngx'
 import { KeyboardEventType } from 'src/app/shared/enums/events'
-import { isValidNHSId } from 'src/app/shared/utilities/form-validators'
 
 @Component({
   selector: 'web-input',
@@ -29,10 +28,13 @@ export class WebInputComponent implements OnInit {
   text: string
   @Input()
   currentlyShown: boolean
+  @Input()
+  url: string
+  @Input()
+  validator
 
   textValue = ''
   inputValid = true
-  NHS_URL = 'https://www.nhs.uk/nhs-services/online-services/find-nhs-number/'
 
   browserOptions: InAppBrowserOptions = {
     location: 'yes',
@@ -50,10 +52,10 @@ export class WebInputComponent implements OnInit {
   ngOnInit() {}
 
   emitAnswer(value) {
-    const cleanedValue = value.replace(/\s/g, '')
-    const valid = isValidNHSId(cleanedValue)
+    const valid = this.validator(this.textValue)
     if (valid) {
       this.valueChange.emit(this.textValue)
+      this.inputValid = true
     } else this.inputValid = false
   }
 
@@ -65,7 +67,7 @@ export class WebInputComponent implements OnInit {
   }
 
   openUrl() {
-    this.openWithInAppBrowser(this.NHS_URL)
+    this.openWithInAppBrowser(this.url)
   }
 
   openWithInAppBrowser(url: string) {

--- a/src/app/shared/models/question.ts
+++ b/src/app/shared/models/question.ts
@@ -95,3 +95,7 @@ export interface QuestionPosition {
   groupKeyIndex: number
   questionIndices: number[]
 }
+
+export enum WebInputType {
+  NHS = 'nhs'
+}

--- a/src/app/shared/utilities/form-validators.ts
+++ b/src/app/shared/utilities/form-validators.ts
@@ -7,17 +7,13 @@ export function isValidURL(URL: string) {
 }
 
 export function isValidNHSId(nhsId: string) {
-  if (nhsId.length !== 10) {
-    return false
-  }
-  const checksum = this.calculateNHSChecksum(nhsId)
+  const checksum = calculateNHSChecksum(nhsId)
   const lastDigit: number = parseInt(nhsId[9], 10)
   return checksum === lastDigit
 }
 
 export function calculateNHSChecksum(nhsId: string): number {
   nhsId = nhsId.replace(/\s/g, '') // Remove any spaces
-
   if (nhsId.length !== 10) {
     throw new Error('Invalid NHS ID length. Expected length is 10.')
   }
@@ -25,6 +21,7 @@ export function calculateNHSChecksum(nhsId: string): number {
   const total: number = nhsId
     .split('')
     .map((digit, index) => parseInt(digit, 10) * weights[index])
+    .slice(0, 9)
     .reduce((acc, curr) => acc + curr, 0)
   const checksum: number = (11 - (total % 11)) % 11
   return checksum

--- a/src/app/shared/utilities/form-validators.ts
+++ b/src/app/shared/utilities/form-validators.ts
@@ -5,3 +5,27 @@ export const URLRegEx = '(https?://)?([\\da-z.-]+)\\.([a-z.]{2,6})[/\\w .-]*/?'
 export function isValidURL(URL: string) {
   return !new FormControl(URL, Validators.pattern(URLRegEx)).errors
 }
+
+export function isValidNHSId(nhsId: string) {
+  if (nhsId.length !== 10) {
+    return false
+  }
+  const checksum = this.calculateNHSChecksum(nhsId)
+  const lastDigit: number = parseInt(nhsId[9], 10)
+  return checksum === lastDigit
+}
+
+export function calculateNHSChecksum(nhsId: string): number {
+  nhsId = nhsId.replace(/\s/g, '') // Remove any spaces
+
+  if (nhsId.length !== 10) {
+    throw new Error('Invalid NHS ID length. Expected length is 10.')
+  }
+  const weights: number[] = [10, 9, 8, 7, 6, 5, 4, 3, 2] // Weights for each digit
+  const total: number = nhsId
+    .split('')
+    .map((digit, index) => parseInt(digit, 10) * weights[index])
+    .reduce((acc, curr) => acc + curr, 0)
+  const checksum: number = (11 - (total % 11)) % 11
+  return checksum
+}


### PR DESCRIPTION
- Add support for NHS/web data input
- This allows the user to open an external URL, get information from that URL, then input this back as text input in the app
- Add `notes` input for larger text input (also called `notes` in REDCap)

Screenshots (using definition here: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/pull/280):

<img src="https://user-images.githubusercontent.com/16977973/242382024-e51581cb-3952-437d-a243-d8ce6cf62ad8.png" width="200px">. <img src="https://user-images.githubusercontent.com/16977973/242382015-9e800274-3601-4a5c-9e1c-e21c57b0c22f.png" width="200px">. <img src="https://user-images.githubusercontent.com/16977973/242382013-88923c8d-b622-4ab8-b14b-cf1acd44d998.png" width="200px">


Solves #1625 

