### PR TITLE
Remove unnecessary questionnaire requests

### DIFF
--- a/src/app/core/services/config/questionnaire.service.ts
+++ b/src/app/core/services/config/questionnaire.service.ts
@@ -27,6 +27,7 @@ export class QuestionnaireService {
     CONIFG_ON_DEMAND_ASSESSMENTS: StorageKeys.CONFIG_ON_DEMAND_ASSESSMENTS,
     CONFIG_CLINICAL_ASSESSMENTS: StorageKeys.CONFIG_CLINICAL_ASSESSMENTS
   }
+  LANG_EN = 'en'
 
   constructor(
     private storage: StorageService,
@@ -70,7 +71,10 @@ export class QuestionnaireService {
       .getContent(uri)
       .catch(e => {
         this.logger.error(`Failed to get questionnaires from ${uri}`, e)
-        uri = this.formatQuestionnaireUri(assessment.questionnaire, '')
+        uri = this.formatQuestionnaireUri(
+          assessment.questionnaire,
+          this.LANG_EN
+        )
         return this.githubClient.getContent(uri) as Promise<Question[]>
       })
       .then(translated => {
@@ -90,7 +94,7 @@ export class QuestionnaireService {
       repo = urlParts[2],
       branch = urlParts[3],
       directory = urlParts.slice(4).join('/')
-    const suffix = lang.length ? `_${lang}` : ''
+    const suffix = lang.length && lang != this.LANG_EN ? `_${lang}` : ''
     const fileName =
       questionnaireName + metadata.type + suffix + metadata.format
     return (

--- a/src/app/core/services/misc/github-client.service.ts
+++ b/src/app/core/services/misc/github-client.service.ts
@@ -13,6 +13,8 @@ import { RemoteConfigService } from '../config/remote-config.service'
 
 @Injectable()
 export class GithubClient {
+  githubFetchStrategy: string
+
   constructor(
     private appServerService: AppServerService,
     private util: Utility,
@@ -38,13 +40,19 @@ export class GithubClient {
   }
 
   getFetchStrategy(): Promise<String> {
-    return this.remoteConfig
-      .read()
-      .then(config =>
-        config.getOrDefault(
-          ConfigKeys.GITHUB_FETCH_STRATEGY,
-          DefaultGithubFetchStrategy
+    if (!this.githubFetchStrategy)
+      return this.remoteConfig
+        .read()
+        .then(config =>
+          config.getOrDefault(
+            ConfigKeys.GITHUB_FETCH_STRATEGY,
+            DefaultGithubFetchStrategy
+          )
         )
-      )
+        .then(strategy => {
+          this.githubFetchStrategy = strategy
+          return strategy
+        })
+    else return Promise.resolve(this.githubFetchStrategy)
   }
 }


### PR DESCRIPTION
- The urls of the http requests for questionniares are formatted in a way that the user's language is the suffix of the url. (eg: `phq8_armt_en.json`). However, in the definitions repository, the default English questionnaires do not have the language suffix. This removes the unnecessary requests to non-existing files.
- Also stores the `githubFetchStrategy` and uses this value instead of reading from the remote config every time a request is made