### PR TITLE
Add explicit notification permission checks for Android

### DIFF
--- a/src/app/core/services/notifications/fcm-notification.service.ts
+++ b/src/app/core/services/notifications/fcm-notification.service.ts
@@ -83,9 +83,10 @@ export abstract class FcmNotificationService extends NotificationService {
   }
 
   async permissionCheck(): Promise<void> {
-    if (!this.platform.is('ios')) return Promise.resolve()
-    const result = await FirebaseMessaging.requestPermissions()
-    return
+    const result = await FirebaseMessaging.checkPermissions()
+    if (result.receive != 'granted') {
+      await FirebaseMessaging.requestPermissions()
+    }
   }
 
   setFCMToken(token) {


### PR DESCRIPTION
- Notification permissions for Android 13+ now need to be explicitly requested as per docs (https://developer.android.com/develop/ui/views/notifications/notification-permission)
- In iOS, we already request this. The update is just to include Android as well. For Android < 13, the previous behaviour will remain. 