### PR TITLE
Add token endpoint fallback

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -58,6 +58,8 @@ import { Utility } from './shared/utilities/util'
 import { DefaultKeyConverterService } from './core/services/kafka/converters/default-key-converter.service'
 import { KeyConverterService } from './core/services/kafka/converters/key-converter.service'
 import { TokenFactoryService } from './core/services/token/token-factory.service'
+import { MPTokenService } from './core/services/token/mp-token.service'
+import { HydraTokenService } from './core/services/token/hydra-token.service'
 
 @NgModule({
   imports: [
@@ -127,6 +129,8 @@ import { TokenFactoryService } from './core/services/token/token-factory.service
     { provide: NotificationService, useClass: NotificationFactoryService },
     { provide: AnalyticsService, useClass: FirebaseAnalyticsService },
     { provide: TokenService, useClass: TokenFactoryService },
+    MPTokenService,
+    HydraTokenService,
     GithubClient
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -57,6 +57,7 @@ import { jwtOptionsFactory } from './shared/utilities/jwtOptionsFactory'
 import { Utility } from './shared/utilities/util'
 import { DefaultKeyConverterService } from './core/services/kafka/converters/default-key-converter.service'
 import { KeyConverterService } from './core/services/kafka/converters/key-converter.service'
+import { TokenFactoryService } from './core/services/token/token-factory.service'
 
 @NgModule({
   imports: [
@@ -103,7 +104,6 @@ import { KeyConverterService } from './core/services/kafka/converters/key-conver
     SubjectConfigService,
     ProtocolService,
     QuestionnaireService,
-    TokenService,
     KafkaService,
     LocalizationService,
     ScheduleGeneratorService,
@@ -126,6 +126,7 @@ import { KeyConverterService } from './core/services/kafka/converters/key-conver
     MessageHandlerService,
     { provide: NotificationService, useClass: NotificationFactoryService },
     { provide: AnalyticsService, useClass: FirebaseAnalyticsService },
+    { provide: TokenService, useClass: TokenFactoryService },
     GithubClient
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]

--- a/src/app/core/containers/app.component.spec.ts
+++ b/src/app/core/containers/app.component.spec.ts
@@ -2,9 +2,10 @@ import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { ComponentFixture, TestBed, async } from '@angular/core/testing'
 import { Platform } from '@ionic/angular'
 
-import { NotificationServiceMock } from '../../shared/testing/mock-services'
+import { NotificationServiceMock, TokenServiceMock } from '../../shared/testing/mock-services'
 import { NotificationService } from '../services/notifications/notification.service'
 import { AppComponent } from './app.component'
+import { TokenService } from '../services/token/token.service'
 
 describe('AppComponent', () => {
   let component: AppComponent
@@ -16,7 +17,8 @@ describe('AppComponent', () => {
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
         Platform,
-        { provide: NotificationService, useClass: NotificationServiceMock }
+        { provide: NotificationService, useClass: NotificationServiceMock },
+        { provide: TokenService, useClass: TokenServiceMock }
       ]
     }).compileComponents()
 

--- a/src/app/core/containers/app.component.ts
+++ b/src/app/core/containers/app.component.ts
@@ -5,6 +5,7 @@ import { TextZoom } from '@capacitor/text-zoom'
 import { Capacitor } from '@capacitor/core'
 
 import { SplashPageComponent } from '../../pages/splash/containers/splash-page.component'
+import { TokenService } from '../services/token/token.service'
 
 @Component({
   selector: 'app-root',
@@ -15,7 +16,7 @@ export class AppComponent {
   rootPage = SplashPageComponent
   isAppInitialized: boolean
 
-  constructor(private platform: Platform) {
+  constructor(private platform: Platform, private token: TokenService) {
     register()
     this.platform.ready().then(() => {
       if (Capacitor.isPluginAvailable('TextZoom')) TextZoom.set({ value: 1 })

--- a/src/app/core/services/token/hydra-token.service.ts
+++ b/src/app/core/services/token/hydra-token.service.ts
@@ -29,7 +29,9 @@ export class HydraTokenService extends TokenService {
   getTokenEndpoint() {
     return this.storage
       .get(this.TOKEN_STORE.TOKEN_ENDPOINT)
-      .then(uri => uri ? uri : DefaultTokenEndPoint)
+      .then(uri => uri ? uri : this.getURI().then(baseUrl =>
+        `${baseUrl}/hydra/oauth2/token`
+      ))
   }
 
   isValid(): Promise<boolean> {

--- a/src/app/core/services/token/hydra-token.service.ts
+++ b/src/app/core/services/token/hydra-token.service.ts
@@ -1,0 +1,75 @@
+import { HttpClient } from '@angular/common/http'
+import { Injectable } from '@angular/core'
+import { JwtHelperService } from '@auth0/angular-jwt'
+import { Platform } from '@ionic/angular'
+
+import { DefaultRequestEncodedContentType, DefaultTokenEndPoint } from '../../../../assets/data/defaultConfig'
+import { RemoteConfigService } from '../config/remote-config.service'
+import { LogService } from '../misc/log.service'
+import { StorageService } from '../storage/storage.service'
+import { TokenService } from './token.service'
+import { OAuthToken } from 'src/app/shared/models/token'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HydraTokenService extends TokenService {
+
+  constructor(
+    public http: HttpClient,
+    public storage: StorageService,
+    public jwtHelper: JwtHelperService,
+    public remoteConfig: RemoteConfigService,
+    public logger: LogService,
+    public platform: Platform
+  ) {
+    super(http, storage, jwtHelper, remoteConfig, logger, platform)
+  }
+
+  getTokenEndpoint() {
+    return this.storage
+      .get(this.TOKEN_STORE.TOKEN_ENDPOINT)
+      .then(uri => uri ? uri : DefaultTokenEndPoint)
+  }
+
+  isValid(): Promise<boolean> {
+    return this.getTokens().then(tokens => {
+      if (!tokens || !tokens.refresh_token) {
+        return false // No token available
+      }
+      // For opaque tokens, assume valid until refreshed
+      return true
+    })
+  }
+
+  register(refreshBody): Promise<OAuthToken> {
+    return Promise.all([
+      this.getTokenEndpoint(),
+      this.getRegisterHeaders(DefaultRequestEncodedContentType)
+    ])
+      .then(([uri, headers]) => {
+        this.logger.log(`"Registering with ${uri} and headers`, headers)
+        return this.http
+          .post(uri, refreshBody, { headers: headers })
+          .toPromise()
+      })
+      .then((res: any) => {
+        res.iat = this.jwtHelper.decodeToken(res.access_token)['iat']
+        this.setTokens(res)
+        return res
+      })
+  }
+
+  handleError(error): any {
+    if (error && error.error === 'invalid_grant') {
+      // Specific check for expired refresh token
+      console.error('Refresh token expired. Please log in again.')
+      this.reset() // Clear tokens and session data
+      throw new Error('Session expired. Please log in again.')
+    }
+    // Handle other errors (e.g., network, server issues)
+    console.error('Error refreshing token:', error)
+    throw new Error('Error refreshing token. Please try again.')
+  }
+
+}

--- a/src/app/core/services/token/hydra-token.service.ts
+++ b/src/app/core/services/token/hydra-token.service.ts
@@ -8,7 +8,7 @@ import { RemoteConfigService } from '../config/remote-config.service'
 import { LogService } from '../misc/log.service'
 import { StorageService } from '../storage/storage.service'
 import { TokenService } from './token.service'
-import { OAuthToken } from 'src/app/shared/models/token'
+import { OAuthToken } from '../../../shared/models/token'
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/core/services/token/mp-token.service.ts
+++ b/src/app/core/services/token/mp-token.service.ts
@@ -1,0 +1,61 @@
+import { HttpClient } from '@angular/common/http'
+import { Injectable } from '@angular/core'
+import { JwtHelperService } from '@auth0/angular-jwt'
+import { Platform } from '@ionic/angular'
+
+import {
+  DefaultRequestEncodedContentType,
+  DefaultManagementPortalURI,
+  DefaultRefreshTokenURI
+} from '../../../../assets/data/defaultConfig'
+import { OAuthToken } from '../../../shared/models/token'
+import { RemoteConfigService } from '../config/remote-config.service'
+import { LogService } from '../misc/log.service'
+import { StorageService } from '../storage/storage.service'
+import { TokenService } from './token.service'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MPTokenService extends TokenService {
+
+  constructor(
+    public http: HttpClient,
+    public storage: StorageService,
+    public jwtHelper: JwtHelperService,
+    public remoteConfig: RemoteConfigService,
+    public logger: LogService,
+    public platform: Platform
+  ) {
+    super(http, storage, jwtHelper, remoteConfig, logger, platform)
+  }
+
+  getTokenEndpoint() {
+    return this.getURI().then(baseUrl =>
+      `${baseUrl}${DefaultManagementPortalURI}${DefaultRefreshTokenURI}`
+    )
+  }
+
+  isValid(): Promise<boolean> {
+    return this.getTokens()
+      .then(tokens => !this.jwtHelper.isTokenExpired(tokens.refresh_token))
+  }
+
+  register(refreshBody): Promise<OAuthToken> {
+    return Promise.all([
+      this.getTokenEndpoint(),
+      this.getRegisterHeaders(DefaultRequestEncodedContentType)
+    ])
+      .then(([uri, headers]) => {
+        this.logger.log(`"Registering with ${uri} and headers`, headers)
+        return this.http
+          .post(uri, refreshBody, { headers: headers })
+          .toPromise()
+      })
+      .then((res: any) => {
+        this.setTokens(res)
+        return res
+      })
+  }
+
+}

--- a/src/app/core/services/token/token-factory.service.ts
+++ b/src/app/core/services/token/token-factory.service.ts
@@ -74,4 +74,8 @@ export class TokenFactoryService extends TokenService {
   async isValid(): Promise<boolean> {
     return this.init().then(() => this.tokenService.isValid())
   }
+
+  reset() {
+    return this.storage.set(StorageKeys.PLATFORM_AUTH_TYPE, null).then(() => super.reset())
+  }
 }

--- a/src/app/core/services/token/token-factory.service.ts
+++ b/src/app/core/services/token/token-factory.service.ts
@@ -19,6 +19,7 @@ import { StorageKeys } from '../../../shared/enums/storage'
 })
 export class TokenFactoryService extends TokenService {
   private tokenService!: TokenService
+  private HYDRA_KEY = 'hydra'
 
   constructor(
     public http: HttpClient,
@@ -40,7 +41,7 @@ export class TokenFactoryService extends TokenService {
 
       if (!authType) {
         const endpoint = await this.storage.get(StorageKeys.TOKEN_ENDPOINT)
-        authType = endpoint ? AuthType.ORY : AuthType.MP
+        authType = endpoint && endpoint.includes(this.HYDRA_KEY) ? AuthType.ORY : AuthType.MP
         await this.storage.set(StorageKeys.PLATFORM_AUTH_TYPE, authType)
       }
 
@@ -71,6 +72,6 @@ export class TokenFactoryService extends TokenService {
   }
 
   async isValid(): Promise<boolean> {
-    return this.tokenService.isValid()
+    return this.init().then(() => this.tokenService.isValid())
   }
 }

--- a/src/app/core/services/token/token-factory.service.ts
+++ b/src/app/core/services/token/token-factory.service.ts
@@ -37,14 +37,12 @@ export class TokenFactoryService extends TokenService {
 
   private async init(): Promise<void> {
     try {
-      let authType = await this.storage.get(StorageKeys.PLATFORM_AUTH_TYPE)
-
+      let authType = await this.getAuthType()
       if (!authType) {
         const endpoint = await this.storage.get(StorageKeys.TOKEN_ENDPOINT)
         authType = endpoint && endpoint.includes(this.HYDRA_KEY) ? AuthType.ORY : AuthType.MP
-        await this.storage.set(StorageKeys.PLATFORM_AUTH_TYPE, authType)
+        await this.setAuthType(authType)
       }
-
       this.tokenService = this.getTokenServiceByType(authType)
     } catch (error) {
       this.logger.error('Error initializing TokenFactoryService', error)

--- a/src/app/core/services/token/token-factory.service.ts
+++ b/src/app/core/services/token/token-factory.service.ts
@@ -9,10 +9,10 @@ import { RemoteConfigService } from '../config/remote-config.service'
 import { LogService } from '../misc/log.service'
 import { StorageService } from '../storage/storage.service'
 import { TokenService } from './token.service'
-import { AuthType } from 'src/app/shared/models/auth'
+import { AuthType } from '../../../shared/models/auth'
 import { HydraTokenService } from './hydra-token.service'
 import { MPTokenService } from './mp-token.service'
-import { StorageKeys } from 'src/app/shared/enums/storage'
+import { StorageKeys } from '../../../shared/enums/storage'
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/core/services/token/token-factory.service.ts
+++ b/src/app/core/services/token/token-factory.service.ts
@@ -4,7 +4,6 @@ import { JwtHelperService } from '@auth0/angular-jwt'
 import { Platform } from '@ionic/angular'
 
 import { DefaultAuthType } from '../../../../assets/data/defaultConfig'
-import { ConfigKeys } from '../../../shared/enums/config'
 import { OAuthToken } from '../../../shared/models/token'
 import { RemoteConfigService } from '../config/remote-config.service'
 import { LogService } from '../misc/log.service'
@@ -13,6 +12,7 @@ import { TokenService } from './token.service'
 import { AuthType } from 'src/app/shared/models/auth'
 import { HydraTokenService } from './hydra-token.service'
 import { MPTokenService } from './mp-token.service'
+import { StorageKeys } from 'src/app/shared/enums/storage'
 
 @Injectable({
   providedIn: 'root'
@@ -35,18 +35,14 @@ export class TokenFactoryService extends TokenService {
   }
 
   init() {
-    return this.remoteConfig
-      .forceFetch()
-      .then(config =>
-        config.getOrDefault(
-          ConfigKeys.NOTIFICATION_MESSAGING_TYPE,
-          DefaultAuthType
-        )
-      )
+    return this.storage
+      .get(StorageKeys.PLATFORM_AUTH_TYPE)
       .then(type => {
-        switch (type) {
-          case AuthType.MP:
+        const authType = type ? type : DefaultAuthType
+        switch (authType) {
+          case AuthType.MP: {
             return (this.tokenService = this.mpTokenService)
+          }
           case AuthType.ORY:
             return (this.tokenService = this.hydraTokenService)
           default:
@@ -58,9 +54,11 @@ export class TokenFactoryService extends TokenService {
   getTokenEndpoint(): Promise<string> {
     return this.tokenService.getTokenEndpoint()
   }
+
   register(refreshBody: any): Promise<OAuthToken> {
     return this.tokenService.register(refreshBody)
   }
+
   isValid(): Promise<boolean> {
     return this.tokenService.isValid()
   }

--- a/src/app/core/services/token/token-factory.service.ts
+++ b/src/app/core/services/token/token-factory.service.ts
@@ -1,0 +1,67 @@
+import { HttpClient } from '@angular/common/http'
+import { Injectable } from '@angular/core'
+import { JwtHelperService } from '@auth0/angular-jwt'
+import { Platform } from '@ionic/angular'
+
+import { DefaultAuthType } from '../../../../assets/data/defaultConfig'
+import { ConfigKeys } from '../../../shared/enums/config'
+import { OAuthToken } from '../../../shared/models/token'
+import { RemoteConfigService } from '../config/remote-config.service'
+import { LogService } from '../misc/log.service'
+import { StorageService } from '../storage/storage.service'
+import { TokenService } from './token.service'
+import { AuthType } from 'src/app/shared/models/auth'
+import { HydraTokenService } from './hydra-token.service'
+import { MPTokenService } from './mp-token.service'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TokenFactoryService extends TokenService {
+  tokenService: TokenService
+
+  constructor(
+    public http: HttpClient,
+    public storage: StorageService,
+    public jwtHelper: JwtHelperService,
+    public remoteConfig: RemoteConfigService,
+    public logger: LogService,
+    public platform: Platform,
+    public hydraTokenService: HydraTokenService,
+    public mpTokenService: MPTokenService,
+  ) {
+    super(http, storage, jwtHelper, remoteConfig, logger, platform)
+    this.init()
+  }
+
+  init() {
+    return this.remoteConfig
+      .forceFetch()
+      .then(config =>
+        config.getOrDefault(
+          ConfigKeys.NOTIFICATION_MESSAGING_TYPE,
+          DefaultAuthType
+        )
+      )
+      .then(type => {
+        switch (type) {
+          case AuthType.MP:
+            return (this.tokenService = this.mpTokenService)
+          case AuthType.ORY:
+            return (this.tokenService = this.hydraTokenService)
+          default:
+            throw new Error('No such token service available')
+        }
+      })
+  }
+
+  getTokenEndpoint(): Promise<string> {
+    return this.tokenService.getTokenEndpoint()
+  }
+  register(refreshBody: any): Promise<OAuthToken> {
+    return this.tokenService.register(refreshBody)
+  }
+  isValid(): Promise<boolean> {
+    return this.tokenService.isValid()
+  }
+}

--- a/src/app/core/services/token/token.service.ts
+++ b/src/app/core/services/token/token.service.ts
@@ -8,8 +8,9 @@ import {
   DefaultOAuthClientId,
   DefaultOAuthClientSecret,
   DefaultRequestEncodedContentType,
-  DefaultTokenEndPoint,
-  DefaultTokenRefreshSeconds
+  DefaultTokenRefreshSeconds,
+  DefaultManagementPortalURI,
+  DefaultRefreshTokenURI
 } from '../../../../assets/data/defaultConfig'
 import { ConfigKeys } from '../../../shared/enums/config'
 import { StorageKeys } from '../../../shared/enums/storage'
@@ -18,7 +19,6 @@ import { getSeconds } from '../../../shared/utilities/time'
 import { RemoteConfigService } from '../config/remote-config.service'
 import { LogService } from '../misc/log.service'
 import { StorageService } from '../storage/storage.service'
-import { DefaultManagementPortalURI, DefaultRefreshTokenURI } from 'www/assets/data/defaultConfig'
 
 @Injectable({
   providedIn: 'root'
@@ -75,7 +75,10 @@ export class TokenService {
   getMPTokenEndpoint() {
     return this.getURI().then(baseUrl =>
       `${baseUrl}${DefaultManagementPortalURI}${DefaultRefreshTokenURI}`
-    )
+    ).then(uri => {
+      this.setTokenEndpoint(uri)
+      return uri
+    })
   }
 
   setTokens(tokens) {

--- a/src/app/core/services/token/token.service.ts
+++ b/src/app/core/services/token/token.service.ts
@@ -18,6 +18,7 @@ import { getSeconds } from '../../../shared/utilities/time'
 import { RemoteConfigService } from '../config/remote-config.service'
 import { LogService } from '../misc/log.service'
 import { StorageService } from '../storage/storage.service'
+import { DefaultManagementPortalURI, DefaultRefreshTokenURI } from 'www/assets/data/defaultConfig'
 
 @Injectable({
   providedIn: 'root'
@@ -68,7 +69,13 @@ export class TokenService {
   getTokenEndpoint() {
     return this.storage
       .get(this.TOKEN_STORE.TOKEN_ENDPOINT)
-      .then(uri => (uri ? uri : DefaultTokenEndPoint))
+      .then(uri => uri ? uri : this.getMPTokenEndpoint())
+  }
+
+  getMPTokenEndpoint() {
+    return this.getURI().then(baseUrl =>
+      `${baseUrl}${DefaultManagementPortalURI}${DefaultRefreshTokenURI}`
+    )
   }
 
   setTokens(tokens) {

--- a/src/app/core/services/token/token.service.ts
+++ b/src/app/core/services/token/token.service.ts
@@ -153,6 +153,14 @@ export abstract class TokenService {
 
   abstract isValid(): Promise<boolean>
 
+  setAuthType(type) {
+    return this.storage.set(StorageKeys.PLATFORM_AUTH_TYPE, type)
+  }
+
+  getAuthType() {
+    return this.storage.get(StorageKeys.PLATFORM_AUTH_TYPE)
+  }
+
   reset() {
     return Promise.all([this.setTokens(null)])
   }

--- a/src/app/pages/auth/auth.module.ts
+++ b/src/app/pages/auth/auth.module.ts
@@ -3,7 +3,6 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { RouterModule, Routes } from '@angular/router'
 import { IonicModule } from '@ionic/angular'
-import { TokenService } from 'src/app/core/services/token/token.service'
 
 import { PipesModule } from '../../shared/pipes/pipes.module'
 import { QRFormComponent } from './components/qr-form/qr-form.component'

--- a/src/app/pages/auth/services/auth.service.ts
+++ b/src/app/pages/auth/services/auth.service.ts
@@ -13,6 +13,7 @@ import { LogService } from '../../../core/services/misc/log.service'
 import { TokenService } from '../../../core/services/token/token.service'
 import { AnalyticsService } from '../../../core/services/usage/analytics.service'
 import { MetaToken, OAuthToken } from '../../../shared/models/token'
+import { AuthType } from '../../../shared/models/auth'
 
 @Injectable({
   providedIn: 'root'
@@ -42,6 +43,7 @@ export class AuthService {
   }
 
   private handleMetaTokenAuth(authObj: any) {
+    this.token.setAuthType(AuthType.MP)
     return this.metaTokenUrlAuth(authObj)
       .then(refreshToken => this.completeAuthentication(refreshToken))
       .catch(err => {
@@ -56,6 +58,7 @@ export class AuthService {
     const baseUrl = new URL(url.searchParams.get('referrer')).origin
     if (encodedData) {
       const tokenData = JSON.parse(decodeURIComponent(encodedData))
+      this.token.setAuthType(AuthType.ORY)
       return this.token
         .setURI(baseUrl)
         .then(() => this.analytics.setUserProperties({ baseUrl }))

--- a/src/app/pages/pages.module.ts
+++ b/src/app/pages/pages.module.ts
@@ -38,6 +38,7 @@ import { QuestionsModule } from './questions/questions.module'
 import { ReportModule } from './report/report.module'
 import { SettingsModule } from './settings/settings.module'
 import { SplashModule } from './splash/splash.module'
+import { TokenFactoryService } from '../core/services/token/token-factory.service'
 
 @NgModule({
   imports: [
@@ -60,7 +61,6 @@ import { SplashModule } from './splash/splash.module'
     SubjectConfigService,
     ProtocolService,
     QuestionnaireService,
-    TokenService,
     KafkaService,
     LocalizationService,
     LocalScheduleService,
@@ -77,7 +77,8 @@ import { SplashModule } from './splash/splash.module'
     MessageHandlerService,
     { provide: NotificationService, useClass: NotificationFactoryService },
     { provide: AnalyticsService, useClass: FirebaseAnalyticsService },
+    { provide: TokenService, useClass: TokenFactoryService },
     GithubClient
   ]
 })
-export class PagesModule {}
+export class PagesModule { }

--- a/src/app/shared/enums/storage.ts
+++ b/src/app/shared/enums/storage.ts
@@ -52,6 +52,8 @@ export class StorageKeys {
 
   static HEALTH_LAST_POLL_TIMES = new StorageKeys('HEALTH_LAST_POLL_TIMES')
 
+  static PLATFORM_AUTH_TYPE = new StorageKeys('PLATFORM_AUTH_TYPE')
+
   constructor(public value: string) { }
 
   toString() {

--- a/src/app/shared/models/auth.ts
+++ b/src/app/shared/models/auth.ts
@@ -1,0 +1,4 @@
+export enum AuthType {
+  MP = 'MP',
+  ORY = 'ORY'
+}

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -10,6 +10,7 @@ import {
 } from '../../app/shared/models/settings'
 import { Task } from '../../app/shared/models/task'
 import { Localisations } from './localisations'
+import { AuthType } from 'src/app/shared/models/auth'
 
 // DEFAULT APP INFO
 
@@ -82,6 +83,8 @@ export const DefaultEnrolmentBaseURL =
 export const DefaultKafkaURI = '/kafka'
 export const DefaultQuestionnaireTypeURI = '_armt'
 export const DefaultQuestionnaireFormatURI = '.json'
+
+export const DefaultAuthType = AuthType.MP // MP or ORY
 
 export const DefaultGooglePlaystoreAppURL =
   'https://play.google.com/store/apps/details?id='


### PR DESCRIPTION
For previous deployments, the `TOKEN_ENDPOINT` wasn't stored in the storage. This is only set during new enrolments. For existing enrolments, the default fallback endpoint is incorrect (default is stage deployment, instead of actual baseurl deployment). This fixes the issue.