### PR TITLE
Add support for a backup refresh token

### DIFF
--- a/src/app/core/services/token/hydra-token.service.ts
+++ b/src/app/core/services/token/hydra-token.service.ts
@@ -68,8 +68,7 @@ export class HydraTokenService extends TokenService {
     if (error && error.error === 'invalid_grant') {
       // Specific check for expired refresh token
       console.error('Refresh token expired. Please log in again.')
-      return this.getTokenFromStorage().then(token => {
-        console.log(token)
+      return this.getTokenFromRemoteStorage().then(token => {
         if (token) {
           return this.register(this.getRefreshParams(token))
         } else {
@@ -84,7 +83,7 @@ export class HydraTokenService extends TokenService {
 
   updateTokenServiceByType(authType: AuthType) { }
 
-  getTokenFromStorage() {
+  getTokenFromRemoteStorage() {
     return this.remoteConfig
       .read()
       .then(config =>

--- a/src/app/core/services/token/token-factory.service.ts
+++ b/src/app/core/services/token/token-factory.service.ts
@@ -68,6 +68,11 @@ export class TokenFactoryService extends TokenService {
     return this.tokenService.getTokenEndpoint()
   }
 
+  refresh(): Promise<OAuthToken> {
+    return this.tokenService.refresh()
+      .catch((error) => this.tokenService.handleError(error))
+  }
+
   async register(refreshBody: any): Promise<OAuthToken> {
     return this.tokenService.register(refreshBody)
   }

--- a/src/app/core/services/token/token.service.ts
+++ b/src/app/core/services/token/token.service.ts
@@ -98,7 +98,7 @@ export abstract class TokenService {
       })
       if (tokens.iat + tokens.expires_in < limit) {
         const params = this.getRefreshParams(tokens.refresh_token)
-        return this.register(params).catch(response => this.handleError(response.error))
+        return this.register(params)
       } else {
         return tokens
       }

--- a/src/app/pages/splash/containers/splash-page.component.ts
+++ b/src/app/pages/splash/containers/splash-page.component.ts
@@ -34,10 +34,10 @@ export class SplashPageComponent {
       .then(enrolled =>
         enrolled
           ? this.splashService
-              .evalEnrolment()
-              .then(valid =>
-                valid ? !!this.onStart() : !!this.resetAndEnrol()
-              )
+            .evalEnrolment()
+            .then(valid =>
+              valid ? !!this.onStart() : !!this.resetAndEnrol()
+            )
           : this.enrol()
       )
   }
@@ -66,6 +66,7 @@ export class SplashPageComponent {
   }
 
   showFetchConfigFail(e) {
+    console.log('Error fetching config')
     console.log(e)
     this.alertService.showAlert({
       header: this.localization.translateKey(LocKeys.STATUS_FAILURE),
@@ -79,7 +80,7 @@ export class SplashPageComponent {
         },
         {
           text: this.localization.translateKey(LocKeys.BTN_DISMISS),
-          handler: () => {}
+          handler: () => { }
         }
       ]
     })

--- a/src/app/pages/splash/containers/splash-page.component.ts
+++ b/src/app/pages/splash/containers/splash-page.component.ts
@@ -66,8 +66,6 @@ export class SplashPageComponent {
   }
 
   showFetchConfigFail(e) {
-    console.log('Error fetching config')
-    console.log(e)
     this.alertService.showAlert({
       header: this.localization.translateKey(LocKeys.STATUS_FAILURE),
       message: this.localization.translateKey(LocKeys.CONFIG_ERROR_DESC),

--- a/src/app/shared/enums/config.ts
+++ b/src/app/shared/enums/config.ts
@@ -51,6 +51,8 @@ export class ConfigKeys {
 
   static AUDIO_ENCODER = new ConfigKeys('audio_encoder')
 
+  static TOKEN_BACKUP = new ConfigKeys('token_backup')
+
   constructor(public value: string) { }
 
   toString() {


### PR DESCRIPTION
- There are issues with single use refresh token for hydra auth
- This adds support for a backup refresh token temporarily for tokens that have not be issued with a grace period
- Graceful refresh token docs here: https://www.ory.sh/docs/hydra/guides/graceful-token-refresh