### PR TITLE
Minor fixes

### DIFF
--- a/src/app/pages/home/containers/home-page.component.ts
+++ b/src/app/pages/home/containers/home-page.component.ts
@@ -55,7 +55,6 @@ export class HomePageComponent implements OnInit, OnDestroy {
   HTML_BREAK = '<br>'
   // How long to wait before refreshing tasks
   TASK_REFRESH_MILLIS = 600_000
-  CACHE_SENDING_ALERT_TIMEOUT = 1_200_000 // 20 minutes
   MIN_CACHE_SIZE_TO_SEND = 5
 
   constructor(

--- a/src/app/pages/tasks/healthkit/containers/healthkit-page.component.ts
+++ b/src/app/pages/tasks/healthkit/containers/healthkit-page.component.ts
@@ -368,7 +368,7 @@ export class HealthkitPageComponent implements OnInit, OnDestroy {
       clearTimeout(this.processingTimeout)
       this.processingTimeout = null
     }
-
+    this.healthkitService.stopProgressMessages()
     this.kafkaProgressSubscription.unsubscribe()
     this.progressBaseOffset = 0
     this.attemptProgress = { success: 0, failed: 0, cacheSize: 0 }

--- a/src/app/pages/tasks/healthkit/containers/healthkit-page.component.ts
+++ b/src/app/pages/tasks/healthkit/containers/healthkit-page.component.ts
@@ -14,6 +14,7 @@ import { LocKeys } from '../../../../shared/enums/localisations'
 import { Task } from '../../../../shared/models/task'
 import { AttemptProgress, HealthkitService, ProgressUpdate } from '../services/healthkit.service'
 import { HealthQuestionnaireProcessorService } from '../services/health-questionnaire-processor.service'
+import { DefaultHealthkitPullTimeout } from 'src/assets/data/defaultConfig'
 
 enum ProcessingState {
   IDLE = 'idle',
@@ -49,7 +50,7 @@ export class HealthkitPageComponent implements OnInit, OnDestroy {
 
   // Constants
   private readonly MAX_RETRY_ATTEMPTS = 5
-  private readonly DATA_UPLOAD_TIMEOUT = 1_200_000 // 20 minutes
+  private readonly DATA_UPLOAD_TIMEOUT = DefaultHealthkitPullTimeout
 
   constructor(
     public navCtrl: NavController,

--- a/src/app/pages/tasks/healthkit/containers/healthkit-page.component.ts
+++ b/src/app/pages/tasks/healthkit/containers/healthkit-page.component.ts
@@ -49,7 +49,7 @@ export class HealthkitPageComponent implements OnInit, OnDestroy {
 
   // Constants
   private readonly MAX_RETRY_ATTEMPTS = 5
-  private readonly DATA_UPLOAD_TIMEOUT = 1_800_000 // 30 minutes
+  private readonly DATA_UPLOAD_TIMEOUT = 1_200_000 // 20 minutes
 
   constructor(
     public navCtrl: NavController,
@@ -306,7 +306,6 @@ export class HealthkitPageComponent implements OnInit, OnDestroy {
       return
     }
     this.attemptProgress = { success, failed, cacheSize }
-    this.healthkitService.stopProgressMessages()
     this.healthkitService.updateKafkaProgress(normalizedProgress, this.progressBaseOffset)
   }
 

--- a/src/app/pages/tasks/healthkit/services/healthkit.service.ts
+++ b/src/app/pages/tasks/healthkit/services/healthkit.service.ts
@@ -16,6 +16,7 @@ import { QuestionnaireService } from 'src/app/core/services/config/questionnaire
 import { BehaviorSubject, Observable } from 'rxjs'
 import { Task } from 'src/app/shared/models/task'
 import { App } from '@capacitor/app'
+import { DefaultHealthkitShowEtaText } from 'src/assets/data/defaultConfig'
 
 export interface HealthDataLoadContext {
   startTime: number
@@ -132,7 +133,7 @@ export class HealthkitService {
       config
         .getOrDefault(
           ConfigKeys.HEALTHKIT_SHOW_ETA_TEXT,
-          'false'
+          DefaultHealthkitShowEtaText
         )
         .then(showEta =>
           (this.showEtaText = showEta.toLowerCase() === 'true')

--- a/src/assets/data/defaultConfig.ts
+++ b/src/assets/data/defaultConfig.ts
@@ -360,3 +360,9 @@ export const DefaultHealthkitPermissions = [
 
 // *Default interval to pull Healthkit data until
 export const DefaultHealthkitInterval = 3106 // days
+
+// *Default Healthkit pull timeout in milliseconds
+export const DefaultHealthkitPullTimeout = 1_200_000 // 20 minutes
+
+// *Default Healthkit show ETA text
+export const DefaultHealthkitShowEtaText = 'false'


### PR DESCRIPTION
- Update healthkit pull timeout to 20 minutes (currently 30 minutes)
- Move default vars to defaultConfig
- Clear progress messages when cleaning resources