### PR TITLE
Add support for vertical slider input

### DIFF
--- a/src/app/pages/questions/components/question/question.component.html
+++ b/src/app/pages/questions/components/question/question.component.html
@@ -83,6 +83,17 @@
       >
       </slider-input>
 
+      <slider-vertical-input
+        *ngSwitchCase="'slider-vertical'"
+        [min]="question.range.min"
+        [max]="question.range.max"
+        [step]="question.range.step"
+        [labelLeft]="question.range.labelLeft"
+        [labelRight]="question.range.labelRight"
+        (valueChange)="emitAnswer($event)"
+      >
+      </slider-vertical-input>
+
       <info-screen
         *ngSwitchCase="'info'"
         [sections]="question.select_choices_or_calculations"

--- a/src/app/pages/questions/components/question/question.component.ts
+++ b/src/app/pages/questions/components/question/question.component.ts
@@ -72,7 +72,8 @@ export class QuestionComponent implements OnInit, OnChanges {
     QuestionType.info,
     QuestionType.text,
     QuestionType.descriptive,
-    QuestionType.slider
+    QuestionType.slider,
+    QuestionType.slider_vertical
   ])
 
   HIDE_FIELD_LABEL_SET: Set<QuestionType> = new Set([
@@ -87,6 +88,7 @@ export class QuestionComponent implements OnInit, OnChanges {
     QuestionType.checkbox,
     QuestionType.yesno,
     QuestionType.slider,
+    QuestionType.slider_vertical,
     QuestionType.range,
     QuestionType.text,
     QuestionType.matrix_radio

--- a/src/app/pages/questions/components/question/question.module.ts
+++ b/src/app/pages/questions/components/question/question.module.ts
@@ -19,6 +19,7 @@ import { RangeInputComponent } from './range-input/range-input.component'
 import { SliderInputComponent } from './slider-input/slider-input.component'
 import { TextInputComponent } from './text-input/text-input.component'
 import { TimedTestComponent } from './timed-test/timed-test.component'
+import { SliderVerticalInputComponent } from './slider-vertical-input/slider-vertical-input.component'
 import { WebInputComponent } from './web-input/web-input.component'
 
 const COMPONENTS = [
@@ -28,6 +29,7 @@ const COMPONENTS = [
   RadioInputComponent,
   RangeInputComponent,
   SliderInputComponent,
+  SliderVerticalInputComponent,
   TimedTestComponent,
   InfoScreenComponent,
   RangeInfoInputComponent,

--- a/src/app/pages/questions/components/question/slider-vertical-input/slider-vertical-input.component.html
+++ b/src/app/pages/questions/components/question/slider-vertical-input/slider-vertical-input.component.html
@@ -1,0 +1,20 @@
+<div class="container">
+  <div class="value-number">{{ value }}</div>
+
+  <div class="slider-side">
+    <div class="label-top">{{ labelRight }}</div>
+
+    <div class="track-row">
+      <input type="range" class="vertical-range" [min]="min" [max]="max" [step]="step" [(ngModel)]="value"
+        (ngModelChange)="onInputChange()" (pointerdown)="showTooltip = true" (pointerup)="showTooltip = false"
+        (pointercancel)="showTooltip = false" />
+      <div class="thumb-tooltip" *ngIf="showTooltip && value !== null" [style.top.px]="thumbTopPx">{{ value }}</div>
+      <div class="bounds-side">
+        <span class="range-bound">{{ max }}</span>
+        <span class="range-bound">{{ min }}</span>
+      </div>
+    </div>
+
+    <div class="label-bottom">{{ labelLeft }}</div>
+  </div>
+</div>

--- a/src/app/pages/questions/components/question/slider-vertical-input/slider-vertical-input.component.scss
+++ b/src/app/pages/questions/components/question/slider-vertical-input/slider-vertical-input.component.scss
@@ -1,0 +1,142 @@
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 30px;          /* Increased clickable area for better UX */
+  height: 300px;        /* The vertical height */
+  background: transparent;
+  writing-mode: bt-lr;  /* Standard for vertical */
+  cursor: pointer;
+}
+
+/* The Track (The thin line) */
+input[type="range"]::-webkit-slider-runnable-track {
+  width: 2px;           /* This makes it a thin line */
+  height: 100%;
+  background: var(--cl-secondary, rgba(255, 255, 255, 0.4));
+  border-radius: 2px;
+  margin: 0 auto;       /* Centers the thin line within the 30px input */
+}
+
+input[type="range"]::-moz-range-track {
+  width: 2px;
+  height: 100%;
+  background: var(--cl-secondary, rgba(255, 255, 255, 0.4));
+  border-radius: 2px;
+}
+
+/* The Thumb (The small handle) */
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 12px;
+  width: 12px;
+  background: var(--cl-secondary, #fff);
+  border-radius: 50%;
+  /* Centers the 16px circle on the 2px line */
+  margin-left: -5px; 
+}
+
+input[type="range"]::-moz-range-thumb {
+  height: 12px;
+  width: 12px;
+  background: var(--cl-secondary, #fff);
+  border-radius: 50%;
+  border: none;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px 0;
+}
+
+.value-number {
+  color: var(--ion-font);
+  font-size: 18px;
+  line-height: 1.35em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 16px;
+  min-width: 52px;
+  height: var(--label-height);
+  border-radius: var(--label-height);
+  background-color: var(--cl-primary-40);
+  margin-bottom: 16px;
+}
+
+.slider-side {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.label-top,
+.label-bottom {
+  color: var(--ion-font);
+  font-size: 14px;
+  line-height: 1.35em;
+  text-align: center;
+  max-width: 160px;
+}
+
+/* Row containing just the track + right-side bounds numbers */
+.track-row {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+
+/* Vertical native range — drag up = higher value */
+.vertical-range {
+  -webkit-appearance: slider-vertical;
+  writing-mode: vertical-lr;
+  direction: rtl;
+  height: 280px;
+  width: 40px;
+  cursor: pointer;
+  accent-color: var(--ion-color-secondary, #3dc2ff);
+}
+
+/* Max at top, min at bottom — floats to the right without affecting centering */
+.bounds-side {
+  position: absolute;
+  left: calc(100%);
+  top: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.range-bound {
+  color: var(--ion-font);
+  font-size: 16px;
+  line-height: 1;
+}
+
+.thumb-tooltip {
+  position: absolute;
+  left: calc(100% + 8px);
+  transform: translateY(-50%);
+  background: var(--ion-color-secondary, #3dc2ff);
+  color: #fff;
+  font-size: 13px;
+  padding: 3px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+  pointer-events: none;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 100%;
+    transform: translateY(-50%);
+    border: 5px solid transparent;
+    border-right-color: var(--ion-color-secondary, #3dc2ff);
+  }
+}

--- a/src/app/pages/questions/components/question/slider-vertical-input/slider-vertical-input.component.ts
+++ b/src/app/pages/questions/components/question/slider-vertical-input/slider-vertical-input.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core'
+
+import { SliderInputComponent } from '../slider-input/slider-input.component'
+
+@Component({
+  selector: 'slider-vertical-input',
+  templateUrl: 'slider-vertical-input.component.html',
+  styleUrls: ['slider-vertical-input.component.scss']
+})
+export class SliderVerticalInputComponent extends SliderInputComponent {
+  showTooltip = false
+
+  get thumbTopPx(): number {
+    const v = this.value ?? this.min
+    const ratio = 1 - (v - this.min) / (this.max - this.min)
+    return Math.round(ratio * 280)
+  }
+}

--- a/src/app/pages/questions/containers/questions-page.component.ts
+++ b/src/app/pages/questions/containers/questions-page.component.ts
@@ -76,6 +76,7 @@ export class QuestionsPageComponent implements OnInit, OnDestroy {
     QuestionType.matrix_radio,
     QuestionType.healthkit,
     QuestionType.slider,
+    QuestionType.slider_vertical,
     QuestionType.yesno
   ])
   MAX_RETRY_ALERT_COUNT = 5

--- a/src/app/shared/models/question.ts
+++ b/src/app/shared/models/question.ts
@@ -51,6 +51,7 @@ export class QuestionType {
   static radio = 'radio'
   static range = 'range'
   static slider = 'slider'
+  static slider_vertical = 'slider-vertical'
   static audio = 'audio'
   static timed = 'timed'
   static info = 'info'


### PR DESCRIPTION
- Add support for vertical slider input 
- Some questionnaires such as `EQ5D5L` require vertical VAS as opposed to the default horizontal slider in the app

Preview:
<img height="355" alt="Screenshot 2026-05-08 at 18 39 44" src="https://github.com/user-attachments/assets/dec27a2b-a545-4b52-be04-13020e65885c" />
