### PR TITLE
Feat/healthkit resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -713,9 +713,9 @@
       }
     },
     "node_modules/del/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -859,6 +859,22 @@
       },
       "peerDependencies": {
         "stylelint": ">=10.1.0"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.5.tgz",
+      "integrity": "sha512-Cr0iIqnWKx3ZTvDUAzG0H/u9dWjLE4c2gTtRLz4pqOBGjfjqdcZSfAObFzKTInLLSmD0ZV1I/mshhPoYSBMMCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/patch-package/node_modules/supports-color": {
@@ -1547,6 +1563,22 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.5.tgz",
+      "integrity": "sha512-gO9vNnIN0FTUGjvTFucIXtBSr1Woymmx/aHQtuU+2OllGU6YFLs99960UD4Dib1kFovVgs59MTXwpFdVoSMZoQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/protractor": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-7.0.0.tgz",
@@ -1734,9 +1766,9 @@
       }
     },
     "node_modules/@ionic/angular/node_modules/@stencil/core": {
-      "version": "4.43.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.3.tgz",
-      "integrity": "sha512-w41W6txhGULvvEfa5AEgwfNGAbK3YGowQYMTWuRvXSIbnkiyRDGLogsYSYtHDlz1JJe645JJIK9Lvh5uquFiSw==",
+      "version": "4.43.4",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.4.tgz",
+      "integrity": "sha512-QWawMM1XIpSz4k+k+VyHZMr2YSxlCNAPWO/jTdJ+2kdgdN7ZQVEFZpc4WBm3E3mrDPTZ79lLcnIPa399bg4XOg==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
@@ -5745,6 +5777,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.5.tgz",
+      "integrity": "sha512-J2ngOB4cNzmqLHh6TYMM/ips8aoZIuzxJnDdWutBw5482jGXiOzsPoEF4j2WJ2mGnm7FBCO4StGcwzOgic70JQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/stylelint-order/node_modules/extglob": {
       "version": "0.3.2",
       "dev": true,
@@ -6011,6 +6059,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.5.tgz",
+      "integrity": "sha512-YyEkaQl08ze3cBzI/4Cm1S+rVh8HMOpCdq8B78JLbNFHhzi4NixVN93xDrHZLztlocEYqi45rHHCgA8kZFidFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/karma-browserify": {
@@ -7561,6 +7625,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.5.tgz",
+      "integrity": "sha512-v+PjvNtSASHOjPDMIai9Yi+aP+Vwox+3WVdg2JB8N9aivJ7lyhp4NVU+J0MV2OkWFPnVO8AE/7xH+72ibUUEnw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/stylefmt/node_modules/arr-diff": {
       "version": "2.0.0",
       "dev": true,
@@ -7819,6 +7899,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.5.tgz",
+      "integrity": "sha512-p+WE6RX+jNILsf+exR29DwgV6B73khEQV0qWUbzxaycxawZ8NE0wA6HnnTxbiw5f4Gx9sJDUBemh9v49lKOORA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/isbinaryfile": {
@@ -8252,9 +8348,9 @@
       }
     },
     "node_modules/selenium-webdriver/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8573,9 +8669,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -9018,6 +9114,22 @@
         "find-root": "^1.0.0",
         "minimatch": "^3.0.4",
         "resolve-from": "^4.0.0"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.5.tgz",
+      "integrity": "sha512-MmKUYGDizYjFia0Rwt8oOgmiFH7zaYlsoQ3tIOfPxOqLssAsEgG0MUdRDm5lliqjiuoog8LyDu9srQk5YwWF3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@ionic/core": {
@@ -9540,6 +9652,22 @@
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.5.tgz",
+      "integrity": "sha512-UHkDFCfSGTuXq08oQltXxSZmH1TXyWsL+4QhZDWvvLl6mEJQqk3u7/wq1LjhrrAXYIllaTtRSzUXl4Olkf2J8A==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/stylefmt/node_modules/postcss-sorting/node_modules/source-map": {
       "version": "0.5.7",
@@ -10180,6 +10308,22 @@
       "version": "0.0.8",
       "license": "ISC"
     },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.5.tgz",
+      "integrity": "sha512-QdRHGeZ2ykl5P0KRmfGBZIHmqcwIsUKWmmpZTOq573jRWwmpfRmS7xOhmDHBj9pxv+6qRMH8tLr2fe+ZKQvCYw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
       "license": "MIT",
@@ -10613,9 +10757,9 @@
       }
     },
     "node_modules/webpack/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10957,9 +11101,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -12070,9 +12214,9 @@
       }
     },
     "node_modules/expand-brackets/node_modules/is-descriptor": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
-      "integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13545,6 +13689,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/esbuild-android-64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.5.tgz",
+      "integrity": "sha512-dYPPkiGNskvZqmIK29OPxolyY3tp+c47+Fsc2WYSOVjEPWNCHNyqhtFqQadcXMJDQt8eN0NMDukbyQgFcHquXg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.4",
       "license": "MIT",
@@ -13648,6 +13808,22 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.5.tgz",
+      "integrity": "sha512-e+duNED9UBop7Vnlap6XKedA/53lIi12xv2ebeNS4gFmu7aKyTrok7DPIZyU5w/ftHD4MUDs5PJUkQPP9xJRzg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/use": {
@@ -14012,6 +14188,22 @@
       },
       "engines": {
         "node": ">=7.0.0"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.5.tgz",
+      "integrity": "sha512-7EgFyP2zjO065XTfdCxiXVEk+f83RQ1JsryN1X/VSX2li9rnHAt2swRbpoz5Vlrl6qjHrCmq5b6yxD13z6RheA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/import-sort-cli/node_modules/p-limit": {
@@ -14809,6 +15001,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.5.tgz",
+      "integrity": "sha512-Yz8w/D8CUPYstvVQujByu6mlf48lKmXkq6bkeSZZxTA626efQOJb26aDGLzmFWx6eg/FwrXgt6SZs9V8Pwy/aA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/pause-stream": {
       "version": "0.0.11",
       "dev": true,
@@ -14885,6 +15093,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.5.tgz",
+      "integrity": "sha512-wvAoHEN+gJ/22gnvhZnS/+2H14HyAxM07m59RSLn3iXrQsdS518jnEWRBnJz3fR6BJa+VUTo0NxYjGaNt7RA7Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
@@ -17789,9 +18013,9 @@
       }
     },
     "node_modules/@npmcli/move-file/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -18133,9 +18357,9 @@
       }
     },
     "node_modules/class-utils/node_modules/is-descriptor": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
-      "integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.8.tgz",
+      "integrity": "sha512-SceYGWXvdqlWa/OnQ5FQuV+NxvNmMRhMw/w9AHkH71hTzveND4BTYgvp16g+oITK47qbOl/3D0bl0iygehWAWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20311,6 +20535,22 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.5.tgz",
+      "integrity": "sha512-2sIzhMUfLNoD+rdmV6AacilCHSxZIoGAU2oT7XmJ0lXcZWnCvCtObvO6D4puxX9YRE97GodciRGDLBaiC6x1SA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -21436,6 +21676,22 @@
       "license": "MIT",
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.5.tgz",
+      "integrity": "sha512-2mMFfkLk3oPWfopA9Plj4hyhqHNuGyp5KQyTT9Rc8hFd8wAn5ZrbJg+gNcLMo2yzf8Uiu0RT6G9B15YN9WQyMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/codelyzer/node_modules/zone.js": {
@@ -22878,6 +23134,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.5.tgz",
+      "integrity": "sha512-M5/EfzV2RsMd/wqwR18CELcenZ8+fFxQAAEO7TJKDmP3knhWSbD72ILzrXFMMwshlPAS1ShCZ90jsxkm+8FlaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/protractor/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -22942,6 +23214,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.5.tgz",
+      "integrity": "sha512-2JQQ5Qs9J0440F/n/aUBNvY6lTo4XP/4lt1TwDfHuo0DY3w5++anw+jTjfouLzbJmFFiwmX7SmUhMnysocx96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/import-sort-style-eslint/node_modules/emoji-regex": {
@@ -23177,9 +23465,9 @@
       }
     },
     "node_modules/import-sort-cli/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24261,6 +24549,22 @@
       "version": "2.0.1",
       "license": "MIT"
     },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.5.tgz",
+      "integrity": "sha512-ne0GFdNLsm4veXbTnYAWjbx3shpNKZJUd6XpNbKNUZaNllDZfYQt0/zRqOg0sc7O8GQ+PjSMv9IpIEULXVTVmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/import-sort-cli/node_modules/braces/node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -24583,6 +24887,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.5.tgz",
+      "integrity": "sha512-KdnSkHxWrJ6Y40ABu+ipTZeRhFtc8dowGyFsZY5prsmMSr1ZTG9zQawguN4/tunJ0wy3+kD54GaGwdcpwWAvZQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/rfdc": {
@@ -25401,9 +25721,9 @@
       }
     },
     "node_modules/karma-coverage-istanbul-reporter/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26293,9 +26613,9 @@
       "license": "MIT"
     },
     "node_modules/tslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/patches/@perfood+capacitor-healthkit+1.3.2.patch
+++ b/patches/@perfood+capacitor-healthkit+1.3.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@perfood/capacitor-healthkit/ios/Plugin/CapacitorHealthkitPlugin.swift b/node_modules/@perfood/capacitor-healthkit/ios/Plugin/CapacitorHealthkitPlugin.swift
-index 0c5d95c..e56b155 100644
+index 0c5d95c..ec2ed01 100644
 --- a/node_modules/@perfood/capacitor-healthkit/ios/Plugin/CapacitorHealthkitPlugin.swift
 +++ b/node_modules/@perfood/capacitor-healthkit/ios/Plugin/CapacitorHealthkitPlugin.swift
 @@ -92,13 +92,16 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
@@ -22,7 +22,48 @@ index 0c5d95c..e56b155 100644
                  types.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.distanceCycling)!)
              case "bloodGlucose":
                  types.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bloodGlucose)!)
-@@ -552,8 +555,8 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
+@@ -308,6 +311,7 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
+ 
+     func generateOutput(sampleName: String, results: [HKSample]?) -> [[String: Any]]? {
+         var output: [[String: Any]] = []
++        let dateFormatter = ISO8601DateFormatter()
+         if results == nil {
+             return output
+         }
+@@ -324,8 +328,8 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
+                 let constructedSample: [String: Any] = [
+                     "uuid": sample.uuid.uuidString,
+                     "timeZone": getTimeZoneString(sample: sample) as String,
+-                    "startDate": ISO8601DateFormatter().string(from: sample.startDate),
+-                    "endDate": ISO8601DateFormatter().string(from: sample.endDate),
++                    "startDate": dateFormatter.string(from: sample.startDate),
++                    "endDate": dateFormatter.string(from: sample.endDate),
+                     "duration": sleepHoursBetweenDates,
+                     "sleepState": sleepState,
+                     "source": sample.sourceRevision.source.name,
+@@ -386,8 +390,8 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
+ 
+                 output.append([
+                     "uuid": sample.uuid.uuidString,
+-                    "startDate": ISO8601DateFormatter().string(from: sample.startDate),
+-                    "endDate": ISO8601DateFormatter().string(from: sample.endDate),
++                    "startDate": dateFormatter.string(from: sample.startDate),
++                    "endDate": dateFormatter.string(from: sample.endDate),
+                     "duration": workoutHoursBetweenDates,
+                     "source": sample.sourceRevision.source.name,
+                     "sourceBundleId": sample.sourceRevision.source.bundleIdentifier,
+@@ -468,8 +472,8 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
+                     "uuid": sample.uuid.uuidString,
+                     "value": sample.quantity.doubleValue(for: unit!),
+                     "unitName": unitName!,
+-                    "startDate": ISO8601DateFormatter().string(from: sample.startDate),
+-                    "endDate": ISO8601DateFormatter().string(from: sample.endDate),
++                    "startDate": dateFormatter.string(from: sample.startDate),
++                    "endDate": dateFormatter.string(from: sample.endDate),
+                     "duration": quantityHoursBetweenDates,
+                     "source": sample.sourceRevision.source.name,
+                     "sourceBundleId": sample.sourceRevision.source.bundleIdentifier,
+@@ -552,8 +556,8 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
          guard let sampleType: HKSampleType = getSampleType(sampleName: _sampleName) else {
              return call.reject("Error in sample name")
          }
@@ -33,7 +74,7 @@ index 0c5d95c..e56b155 100644
              _, results, _ in
              guard let output: [[String: Any]] = self.generateOutput(sampleName: _sampleName, results: results) else {
                  return call.reject("Error happened while generating outputs")
-@@ -664,8 +667,8 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
+@@ -664,8 +668,8 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
          guard let sampleType: HKSampleType = getSampleType(sampleName: sampleName) else {
              return completion(.failure(HKSampleError.sampleTypeFailed))
          }

--- a/src/app/core/services/kafka/converters/healthkit-converter.service.ts
+++ b/src/app/core/services/kafka/converters/healthkit-converter.service.ts
@@ -114,7 +114,7 @@ export class HealthkitConverterService extends ConverterService {
         const processedData = await this.processSingleDatatype(
           name,
           res,
-          Date.now()
+          Date.now() / 1000
         )
         const avroData = this.batchConvertToAvro(
           processedData,
@@ -129,15 +129,15 @@ export class HealthkitConverterService extends ConverterService {
   convertToHealthkitRecordPaged$(
     kafkaValue,
     valueSchemaMetadata,
-    pageSize = 3600
+    pageSize = 1000
   ): Observable<any[]> {
     const data = kafkaValue.data
     const name = data.key
-    const startTime = data.value.startTime
-    const endTime = data.value.endTime
+    const startTime = new Date(data.value.startTime)
+    const endTime = new Date(data.value.endTime)
 
     return this.healthkit.queryPaged$(startTime, endTime, name, pageSize).pipe(
-      concatMap(res => from(this.processSingleDatatype(name, res, Date.now()))),
+      concatMap(res => from(this.processSingleDatatype(name, res, Date.now() / 1000))),
       map(processedData => this.batchConvertToAvro(processedData, valueSchemaMetadata))
     )
   }

--- a/src/app/core/services/kafka/converters/healthkit-converter.service.ts
+++ b/src/app/core/services/kafka/converters/healthkit-converter.service.ts
@@ -129,7 +129,7 @@ export class HealthkitConverterService extends ConverterService {
   convertToHealthkitRecordPaged$(
     kafkaValue,
     valueSchemaMetadata,
-    pageSize = 1000
+    pageSize = 3600
   ): Observable<any[]> {
     const data = kafkaValue.data
     const name = data.key

--- a/src/app/core/services/kafka/kafka.service.ts
+++ b/src/app/core/services/kafka/kafka.service.ts
@@ -30,7 +30,7 @@ import { AnalyticsService } from '../usage/analytics.service'
 import { CacheService } from './cache.service'
 import { SchemaService } from './schema.service'
 import { from, isObservable, Observable, of, Subject } from 'rxjs'
-import { concatMap } from 'rxjs/operators'
+import { mergeMap } from 'rxjs/operators'
 import { NotificationService } from '../notifications/notification.service'
 import { NotificationActionType } from 'src/app/shared/models/notification-handler'
 
@@ -52,9 +52,11 @@ interface SendFromCacheOptions {
 export class KafkaService {
   private static DEFAULT_TOPIC_CACHE_VALIDITY = 600_000 // 10 minutes
   private static BATCH_SIZE = 10
-  private static CONCURRENCY_LIMIT = 5
+  private static CONCURRENCY_LIMIT = 1
   private static SEND_ERROR_NOTIFICATION_THRESHOLD = 10
   private static HTTP_TIMEOUT = 120_000 // 2 minutes
+  private static HTTP_RETRY_MAX_ATTEMPTS = 3
+  private static HTTP_RETRY_BASE_DELAY_MS = 1000
 
   URI_topics: string = '/topics/'
   DEFAULT_KAFKA_AVSC = 'questionnaire'
@@ -280,7 +282,9 @@ export class KafkaService {
                 headers,
                 options
               )
-              if (sentRecordCount === 0) this.logger.log('Kafka record is empty, skipping sending')
+              if (sentRecordCount === 0) {
+                this.logger.log('Kafka record is empty, skipping sending')
+              }
               batchSuccessKeys.push(k)
             } catch (e) {
               if (e.message === 'Cache sending cancelled') {
@@ -384,7 +388,7 @@ export class KafkaService {
     return new Promise((resolve, reject) => {
       payloadStream
         .pipe(
-          concatMap(payload => {
+          mergeMap(payload => {
             if (this.cancelSending) {
               throw new Error('Cache sending cancelled')
             }
@@ -396,7 +400,7 @@ export class KafkaService {
                 () => payload.record.records.length
               )
             )
-          })
+          }, 1)
         )
         .subscribe({
           next: sentCount => {
@@ -423,13 +427,12 @@ export class KafkaService {
     return options.streamHealthkitPayloads !== false
   }
 
-  sendToKafka(topic, record, headers): Promise<any> {
-    const allRecords = record.records
+  async sendToKafka(topic, record, headers): Promise<any> {
     const jsonData = JSON.stringify(record)
     // Compress with pako and convert directly to base64
     const gzippedBytesB64 = fromByteArray(pako.gzip(jsonData))
 
-    return this.postData(
+    return await this.postData(
       gzippedBytesB64,
       topic,
       headers.set('Content-Encoding', DefaultCompressedContentEncoding),
@@ -486,7 +489,7 @@ export class KafkaService {
     return result
   }
 
-  postData(data: any, topic: string, headers: HttpHeaders, isBase64: boolean = false): Promise<any> {
+  async postData(data: any, topic: string, headers: HttpHeaders, isBase64: boolean = false): Promise<any> {
     const nativeHeaders = this.convertHeaders(headers)
     const request: any = {
       url: `${this.KAFKA_CLIENT_URL}${this.URI_topics}${topic}`,
@@ -503,27 +506,66 @@ export class KafkaService {
     request.connectionTimeout = KafkaService.HTTP_TIMEOUT
     request.readTimeout = KafkaService.HTTP_TIMEOUT
 
-    const requestPromise = Http.request(request)
-      .then(response => {
+    for (let attempt = 1; attempt <= KafkaService.HTTP_RETRY_MAX_ATTEMPTS; attempt++) {
+      // const httpStart = Date.now()
+      try {
+        const response = await Http.request(request)
+        // console.log('Kafka HTTP request time', {
+        //   topic,
+        //   status: response.status,
+        //   compressed: isBase64,
+        //   bytes: typeof data === 'string' ? data.length : undefined,
+        //   attempt,
+        //   milliseconds: Date.now() - httpStart
+        // })
         if (response.status < 200 || response.status >= 300) {
+          if (this.shouldRetryHttpStatus(response.status, attempt)) {
+            await this.delayHttpRetry(attempt, response.status, topic)
+            continue
+          }
           throw new HttpErrorResponse({
             error: response.data,
             status: response.status,
           })
         }
         return response
-      })
-      .catch(error => {
+      } catch (error) {
+        // console.log('Kafka HTTP request failed time', {
+        //   topic,
+        //   compressed: isBase64,
+        //   bytes: typeof data === 'string' ? data.length : undefined,
+        //   attempt,
+        //   milliseconds: Date.now() - httpStart
+        // })
         console.error('HTTP request failed:', error)
-
         if (this.cancelSending) {
           throw new Error('Request cancelled by user')
         }
+        if (this.shouldRetryHttpStatus(error?.status, attempt)) {
+          await this.delayHttpRetry(attempt, error.status, topic)
+          continue
+        }
+        throw error
+      }
+    }
 
-        throw new Error(`Failed to send data to Kafka: ${error.message}`)
-      })
+    throw new Error('Failed to send data to Kafka after retry attempts')
+  }
 
-    return requestPromise
+  private shouldRetryHttpStatus(status: number, attempt: number): boolean {
+    return attempt < KafkaService.HTTP_RETRY_MAX_ATTEMPTS && (status === 500 || status === 503)
+  }
+
+  private delayHttpRetry(attempt: number, status: number, topic: string): Promise<void> {
+    const delayMs = KafkaService.HTTP_RETRY_BASE_DELAY_MS * attempt
+    // console.log('Retrying Kafka HTTP request', {
+    //   topic,
+    //   status,
+    //   attempt,
+    //   nextAttempt: attempt + 1,
+    //   delayMs
+    // })
+    return new Promise(resolve => setTimeout(resolve, delayMs))
   }
 
   getAccessToken() {

--- a/src/app/core/services/kafka/kafka.service.ts
+++ b/src/app/core/services/kafka/kafka.service.ts
@@ -8,7 +8,7 @@ import { Network } from '@capacitor/network'
 import * as pako from 'pako'
 import { fromByteArray } from 'base64-js'
 import pLimit from 'p-limit'
-import { Http } from '@capacitor-community/http'
+import { Http, HttpOptions } from '@capacitor-community/http'
 
 import {
   DefaultClientAcceptType,
@@ -34,6 +34,10 @@ import { mergeMap } from 'rxjs/operators'
 import { NotificationService } from '../notifications/notification.service'
 import { NotificationActionType } from 'src/app/shared/models/notification-handler'
 
+type NativeHttpOptions = HttpOptions & {
+  dataIsBase64?: boolean
+}
+
 interface PrepareKafkaOptions {
   sendEvent?: boolean
 }
@@ -52,10 +56,10 @@ interface SendFromCacheOptions {
 export class KafkaService {
   private static DEFAULT_TOPIC_CACHE_VALIDITY = 600_000 // 10 minutes
   private static BATCH_SIZE = 10
-  private static CONCURRENCY_LIMIT = 1
+  private static CONCURRENCY_LIMIT = 4
   private static SEND_ERROR_NOTIFICATION_THRESHOLD = 10
-  private static HTTP_TIMEOUT = 120_000 // 2 minutes
-  private static HTTP_RETRY_MAX_ATTEMPTS = 3
+  private static HTTP_TIMEOUT = 20_000 // 20 second [old: 120_000 // 2 minutes]
+  private static HTTP_RETRY_MAX_ATTEMPTS = 5
   private static HTTP_RETRY_BASE_DELAY_MS = 1000
 
   URI_topics: string = '/topics/'
@@ -491,33 +495,21 @@ export class KafkaService {
 
   async postData(data: any, topic: string, headers: HttpHeaders, isBase64: boolean = false): Promise<any> {
     const nativeHeaders = this.convertHeaders(headers)
-    const request: any = {
+    const request: NativeHttpOptions = {
       url: `${this.KAFKA_CLIENT_URL}${this.URI_topics}${topic}`,
       headers: nativeHeaders,
       method: 'POST',
     }
-
-    if (isBase64) {
-      request.data = data // base64 string
-      request.dataIsBase64 = true
-    } else {
-      request.data = data
-    }
-    request.connectionTimeout = KafkaService.HTTP_TIMEOUT
+    request.data = data 
+    request.dataIsBase64 = isBase64
+    request.connectTimeout = KafkaService.HTTP_TIMEOUT
     request.readTimeout = KafkaService.HTTP_TIMEOUT
-
     for (let attempt = 1; attempt <= KafkaService.HTTP_RETRY_MAX_ATTEMPTS; attempt++) {
-      // const httpStart = Date.now()
       try {
-        const response = await Http.request(request)
-        // console.log('Kafka HTTP request time', {
-        //   topic,
-        //   status: response.status,
-        //   compressed: isBase64,
-        //   bytes: typeof data === 'string' ? data.length : undefined,
-        //   attempt,
-        //   milliseconds: Date.now() - httpStart
-        // })
+        const response = await this.withHttpTimeout(
+          Http.request(request),
+          KafkaService.HTTP_TIMEOUT
+        )
         if (response.status < 200 || response.status >= 300) {
           if (this.shouldRetryHttpStatus(response.status, attempt)) {
             await this.delayHttpRetry(attempt, response.status, topic)
@@ -530,19 +522,11 @@ export class KafkaService {
         }
         return response
       } catch (error) {
-        // console.log('Kafka HTTP request failed time', {
-        //   topic,
-        //   compressed: isBase64,
-        //   bytes: typeof data === 'string' ? data.length : undefined,
-        //   attempt,
-        //   milliseconds: Date.now() - httpStart
-        // })
-        console.error('HTTP request failed:', error)
         if (this.cancelSending) {
           throw new Error('Request cancelled by user')
         }
-        if (this.shouldRetryHttpStatus(error?.status, attempt)) {
-          await this.delayHttpRetry(attempt, error.status, topic)
+        if (this.shouldRetryHttpError(error, attempt)) {
+          await this.delayHttpRetry(attempt, error?.status || 'timeout', topic)
           continue
         }
         throw error
@@ -556,15 +540,35 @@ export class KafkaService {
     return attempt < KafkaService.HTTP_RETRY_MAX_ATTEMPTS && (status === 500 || status === 503)
   }
 
-  private delayHttpRetry(attempt: number, status: number, topic: string): Promise<void> {
+  private shouldRetryHttpError(error: any, attempt: number): boolean {
+    if (attempt >= KafkaService.HTTP_RETRY_MAX_ATTEMPTS) return false
+    if (error?.status === 500 || error?.status === 503) return true
+    return this.isHttpTimeoutError(error)
+  }
+
+  private withHttpTimeout<T>(requestPromise: Promise<T>, timeoutMs: number): Promise<T> {
+    let timeoutId: any
+    const timeoutPromise = new Promise<T>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        const error: any = new Error(`Kafka HTTP request timed out after ${timeoutMs}ms`)
+        error.name = 'KafkaHttpTimeoutError'
+        error.status = 'timeout'
+        reject(error)
+      }, timeoutMs)
+    })
+
+    return Promise.race([requestPromise, timeoutPromise])
+      .finally(() => clearTimeout(timeoutId))
+  }
+
+  private isHttpTimeoutError(error: any): boolean {
+    return error?.name === 'KafkaHttpTimeoutError' ||
+      error?.status === 'timeout' ||
+      error?.code === -1001
+  }
+
+  private delayHttpRetry(attempt: number, status: number | string, topic: string): Promise<void> {
     const delayMs = KafkaService.HTTP_RETRY_BASE_DELAY_MS * attempt
-    // console.log('Retrying Kafka HTTP request', {
-    //   topic,
-    //   status,
-    //   attempt,
-    //   nextAttempt: attempt + 1,
-    //   delayMs
-    // })
     return new Promise(resolve => setTimeout(resolve, delayMs))
   }
 

--- a/src/app/pages/tasks/healthkit/services/health-questionnaire-processor.service.ts
+++ b/src/app/pages/tasks/healthkit/services/health-questionnaire-processor.service.ts
@@ -82,9 +82,14 @@ export class HealthQuestionnaireProcessorService extends QuestionnaireProcessorS
               .then(() => this.healthkit.setUploadReadyFlag(true))
               .then(() => this.kafka.sendAllFromCache())
               .then((sendResult) => {
-                const allSent = sendResult && Array.isArray(sendResult.failedKeys) && sendResult.failedKeys.length === 0 && !sendResult.cancelled
-                const hasHealthkitFailedKeys = sendResult && Array.isArray(sendResult.failedKeys) && sendResult.failedKeys.filter((key) => key.startsWith(SchemaType.HEALTHKIT)).length > 0
-                if (!allSent && hasHealthkitFailedKeys) {
+                const failedKeys = sendResult && Array.isArray(sendResult.failedKeys) ? sendResult.failedKeys : []
+                const cancelled = Boolean(sendResult && sendResult.cancelled)
+                const hasHealthkitFailedKeys = failedKeys.filter((key) => key.startsWith(SchemaType.HEALTHKIT)).length > 0
+                if (cancelled) {
+                  worker.terminate()
+                  return Promise.reject(new Error('HealthKit upload was cancelled before completion.'))
+                }
+                if (hasHealthkitFailedKeys) {
                   worker.terminate()
                   return Promise.reject(new Error('Not all HealthKit data could be sent.'))
                 }
@@ -139,9 +144,13 @@ export class HealthQuestionnaireProcessorService extends QuestionnaireProcessorS
           .then(() => this.healthkit.setUploadReadyFlag(true))
           .then(() => this.kafka.sendAllFromCache())
           .then((sendResult) => {
-            const allSent = sendResult && Array.isArray(sendResult.failedKeys) && sendResult.failedKeys.length === 0 && !sendResult.cancelled
-            const hasHealthkitFailedKeys = sendResult && Array.isArray(sendResult.failedKeys) && sendResult.failedKeys.filter((key) => key.startsWith(SchemaType.HEALTHKIT)).length > 0
-            if (!allSent && hasHealthkitFailedKeys) {
+            const failedKeys = sendResult && Array.isArray(sendResult.failedKeys) ? sendResult.failedKeys : []
+            const cancelled = Boolean(sendResult && sendResult.cancelled)
+            const hasHealthkitFailedKeys = failedKeys.filter((key) => key.startsWith(SchemaType.HEALTHKIT)).length > 0
+            if (cancelled) {
+              return Promise.reject(new Error('HealthKit upload was cancelled before completion.'))
+            }
+            if (hasHealthkitFailedKeys) {
               return Promise.reject(new Error('Not all HealthKit data could be sent.'))
             }
             return this.healthkit.setUploadReadyFlag(false)


### PR DESCRIPTION
This PR improves the HealthKit upload flow so interrupted uploads can resume more reliably from cache, particularly after a timeout or cancelled Kafka send.

**Changes**

- Preserve HEALTHKIT_UPLOAD_READY when a HealthKit upload is cancelled before completion, so retry/re-entry can resume from cached data instead of restarting the full pull.
- Treat cancelled HealthKit uploads separately from successful sends and failed-key sends.
- Add retry handling for Kafka postData requests that receive transient server errors (500 or 503), with bounded retry attempts and backoff.
- Reduce Kafka cache send concurrency to limit pressure on the app/server during large HealthKit uploads.
- Make streamed Kafka upload concurrency explicit with mergeMap.
- Ensure HealthKit query start/end values are normalized as Date objects before paged querying.
- Change HealthKit timeReceived values from milliseconds to seconds. - Unsure if this is wanted, consistent with other radar schemas but so far all healthkit data has had timeReceived in milliseconds afaik so it might be a breaking change for analysis.
- Update the HealthKit iOS patch to reuse ISO8601DateFormatter, reducing repeated formatter construction while serializing samples.
